### PR TITLE
Better Filtering

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
@@ -136,6 +136,7 @@ import it.fast4x.rimusic.utils.isNowPlaying
 import it.fast4x.rimusic.utils.isRecommendationEnabledKey
 import it.fast4x.rimusic.utils.manageDownload
 import it.fast4x.rimusic.utils.maxSongsInQueueKey
+import it.fast4x.rimusic.utils.operatorFilterSong
 import it.fast4x.rimusic.utils.recommendationsNumberKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
@@ -327,11 +328,7 @@ fun BuiltInPlaylistSongs(
     filterCharSequence = filter.toString()
     //Log.d("mediaItemFilter", "<${filter}>  <${filterCharSequence}>")
     if (!filter.isNullOrBlank())
-    songs = songs
-        .filter {
-            it.title.contains(filterCharSequence,true)
-            || it.artistsText?.contains(filterCharSequence,true) ?: false
-        }
+        songs = songs.operatorFilterSong(filterCharSequence)
 
     var searching by rememberSaveable { mutableStateOf(false) }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbum.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbum.kt
@@ -91,6 +91,7 @@ import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.filterByKey
 import it.fast4x.rimusic.utils.importYTMLikedAlbums
+import it.fast4x.rimusic.utils.operatorFilterAlbum
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.showFloatingIconKey
@@ -177,11 +178,7 @@ fun HomeAlbums(
         val scrollIndex = lazyGridState.firstVisibleItemIndex
         val scrollOffset = lazyGridState.firstVisibleItemScrollOffset
 
-        itemsOnDisplay = items.filter {
-            it.title?.contains( search.input, true) ?: false
-                    || it.year?.contains( search.input, true) ?: false
-                    || it.authorsText?.contains( search.input, true) ?: false
-        }
+        itemsOnDisplay = items.operatorFilterAlbum(search.input)
 
         lazyGridState.scrollToItem( scrollIndex, scrollOffset )
     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -125,6 +125,7 @@ import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.isPipedEnabledKey
 import it.fast4x.rimusic.utils.isRecommendationEnabledKey
 import it.fast4x.rimusic.utils.manageDownload
+import it.fast4x.rimusic.utils.operatorFilterSong
 import it.fast4x.rimusic.utils.parentalControlEnabledKey
 import it.fast4x.rimusic.utils.recommendationsNumberKey
 import it.fast4x.rimusic.utils.rememberPreference
@@ -453,14 +454,7 @@ fun LocalPlaylistSongs(
              }
              .distinctBy( Song::id )
              .filter { !parentalControlEnabled || !it.title.startsWith( EXPLICIT_PREFIX ) }
-             .filter { song ->
-                 // Without cleaning, user can search explicit songs with "e:"
-                 // I kinda want this to be a feature, but it seems unnecessary
-                 val containsName = song.cleanTitle().contains(search.input, true)
-                 val containsArtist = song.artistsText?.contains(search.input, true) ?: false
-
-                 containsName || containsArtist
-             }
+            .operatorFilterSong(search.input)
             .let { itemsOnDisplay = it }
     }
     LaunchedEffect( playlist?.name ) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -129,6 +129,7 @@ import it.fast4x.rimusic.utils.isCompositionLaunched
 import it.fast4x.rimusic.utils.isNowPlaying
 import it.fast4x.rimusic.utils.onDeviceFolderSortByKey
 import it.fast4x.rimusic.utils.onDeviceSongSortByKey
+import it.fast4x.rimusic.utils.operatorFilterSongEntity
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
@@ -273,11 +274,7 @@ fun DeviceListSongs(
         filterCharSequence = filter.toString()
         //Log.d("mediaItemFilter", "<${filter}>  <${filterCharSequence}>")
         if (!filter.isNullOrBlank())
-            filteredSongs = songs
-                .filter {
-                    it.song.title.contains(filterCharSequence,true) ?: false
-                            || it.song.artistsText?.contains(filterCharSequence,true) ?: false
-                }
+            filteredSongs = songs.operatorFilterSongEntity(filterCharSequence)
         if (!filter.isNullOrBlank())
             filteredFolders = folders
                 .filter {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
@@ -88,6 +88,7 @@ import it.fast4x.rimusic.utils.isDownloadedSong
 import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.isNowPlaying
 import it.fast4x.rimusic.utils.manageDownload
+import it.fast4x.rimusic.utils.operatorFilterSong
 import it.fast4x.rimusic.utils.queueTypeKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.shouldBePlaying
@@ -162,20 +163,12 @@ fun Queue(
 
         val search = Search.init()
         LaunchedEffect( items, search.input ) {
-            items.filter {
-                    // Without cleaning, user can search explicit songs with "e:"
-                    // I kinda want this to be a feature, but it seems unnecessary
-                    val containsTitle = it.cleanTitle().contains( search.input, true )
-                    val containsArtist = it.artistsText?.contains( search.input, true ) ?: false
+            items.operatorFilterSong(search.input).let {
+                itemsOnDisplay = it
 
-                    containsTitle || containsArtist
-                }
-                .let {
-                    itemsOnDisplay = it
-
-                    // Keep scroll at top to prevent weird artifact
-                    lazyListState.scrollToItem( 0, 0 )
-                }
+                // Keep scroll at top to prevent weird artifact
+                lazyListState.scrollToItem( 0, 0 )
+            }
         }
 
         val plistName = remember { mutableStateOf("") }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
@@ -130,6 +130,7 @@ import it.fast4x.rimusic.utils.isNetworkConnected
 import it.fast4x.rimusic.utils.languageDestination
 import it.fast4x.rimusic.utils.manageDownload
 import it.fast4x.rimusic.utils.medium
+import it.fast4x.rimusic.utils.operatorFilterSongItem
 import it.fast4x.rimusic.utils.parentalControlEnabledKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.resize
@@ -230,20 +231,7 @@ fun PlaylistSongList(
     //Log.d("mediaItemFilter", "<${filter}>  <${filterCharSequence}>")
     if (!filter.isNullOrBlank()) {
         playlistPage?.songs =
-            playlistPage?.songs?.filter { songItem ->
-                songItem.asMediaItem.mediaMetadata.title?.contains(
-                    filterCharSequence,
-                    true
-                ) ?: false
-                        || songItem.asMediaItem.mediaMetadata.artist?.contains(
-                    filterCharSequence,
-                    true
-                ) ?: false
-                        || songItem.asMediaItem.mediaMetadata.albumTitle?.contains(
-                    filterCharSequence,
-                    true
-                ) ?: false
-            }!!
+            playlistPage?.songs?.operatorFilterSongItem(filterCharSequence)!!
     } else playlistPage?.songs = playlistSongs
 
     var playlistNotLikedSongs by persistList<Innertube.SongItem>("")

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
@@ -79,6 +79,7 @@ fun isWithinDurationRange(duration: String, range: String): Boolean {
 }
 
 // These are the possible autocomplete buttons: (what they will type in -> the display string).
+// TODO: Implement for the filter searchbar
 val filterTokensForAutocomplete = listOf(
     context().getString(R.string.sort_title).lowercase() + ":"
             to context().getString(R.string.sort_title),
@@ -119,13 +120,17 @@ fun filterMediaMetadata(metadata: MediaMetadata, filter: String): Boolean {
         context().getString(R.string.sort_year).lowercase() to (metadata.releaseYear.toString()),
     )
 
+    // This first any just means include it if any of the ORs applies
     val included = tokenGroups.any { group -> // TODO slight bug with multiple exclusion tokens.
+        // The tokens between an ORs are ANDed together, so all must apply
         group.all { token ->
+            // If there is a search field, only check that. Otherwise, check everything.
             val searchFields = if (metadataFields.containsKey(token.field)) {
                 listOf(metadataFields[token.field] ?: "")
             } else {
                 metadataFields.values
             }
+            // Check that any of the search fields apply
             searchFields.any {
                 val groupApplies = when(token.valueType) {
                     "IntRange" -> isWithinIntRange(it, token.value)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
@@ -1,0 +1,170 @@
+package it.fast4x.rimusic.utils
+
+import androidx.media3.common.MediaMetadata
+import app.kreate.android.R
+import it.fast4x.innertube.Innertube.SongItem
+import it.fast4x.rimusic.context
+import it.fast4x.rimusic.models.Album
+import it.fast4x.rimusic.models.Song
+import it.fast4x.rimusic.models.SongEntity
+import kotlin.text.contains
+
+data class Token(val field: String, val value: String,
+                 val shouldInclude: Boolean, val valueType: String? = null)
+
+/*
+    Filtering can be done for songs or albums.
+    Default behavior works same as before.
+    But now, you can specify a label:value or label:"value"
+    The label can be title, artist, album, duration, year, explicit.
+    Range format is duration:"0:00-10:00", year:2000-2015.
+    Mentioning the word explicit will also include explicit.
+    You can use OR / | to separate groups.
+    Finally, negative (-) can inverse a filter.
+ */
+
+/*
+    In the future, it would be nice to be able to easily sort albums by length and easily sort
+    songs by year. But this information is not directly attached to their respective objects,
+    and I'm not sure how to get them.
+*/
+fun parseSearchQuery(query: String): List<List<Token>> {
+    // The search tokens can be labeled (with quotes), labeled (without quotes),
+    // unlabeled (with quotes) and unlabeled (without quotes).
+    // Assumption about labels: they will not include numbers, whitespace or quotes.
+    val regex = Regex("""(-?)([^"\s\d]+):"([^"]+)"|(-?)([^"\s\d]+):(\S+)|(-?)"([^"]+)"|(-?)(\S+)""")
+    val tokens = mutableListOf<List<Token>>()
+    var currentGroup = mutableListOf<Token>()
+
+    // Find all the search tokens.
+    regex.findAll(query).forEach { match ->
+        val (neg1, field1, value1, neg2, field2, value2, neg3, value3, neg4, value4) = match.destructured
+        val include = !(neg1 == "-" || neg2 == "-" || neg3 == "-" || neg4 == "-")
+        val field = field1.ifEmpty { field2.ifEmpty { "" } }.lowercase()
+        val value = value1.ifEmpty { value2.ifEmpty { value3.ifEmpty { value4 } } }
+        // By default, everything is AND (original behavior). Separate groups based on OR placement.
+        val or = context().getString(R.string.or_operator)
+        if (value.equals(or, ignoreCase = true) || value == "|") {
+            tokens.add(currentGroup)
+            currentGroup = mutableListOf()
+        } else {
+            val explicitRString = context().getString(R.string.explicit).lowercase()
+            val valueType = when {
+                value.contains("-") -> when {
+                    value.contains(":") -> "DurationRange"
+                    else -> "IntRange"
+                }
+                value.equals(explicitRString, ignoreCase = true) -> "ExplicitValue"
+                else -> null
+            }
+            currentGroup.add(Token(field, value, include, valueType))
+        }
+    }
+
+    if (currentGroup.isNotEmpty()) tokens.add(currentGroup)
+    return tokens
+}
+
+fun isWithinIntRange(number: String, range: String): Boolean {
+    var (min, max) = range.split("-").map { it.toIntOrNull() }
+    min = min ?: 0
+    max = max ?: Int.MAX_VALUE
+    return number.toIntOrNull()?.let { it in min..max } == true
+}
+
+fun isWithinDurationRange(duration: String, range: String): Boolean {
+    var (min, max) = range.split("-").map { durationTextToMillis(it) }
+    if (max == 0L) max = Long.MAX_VALUE // Default to infinite
+    return durationTextToMillis(duration) in min..max == true
+}
+
+// These are the possible autocomplete buttons: (what they will type in -> the display string).
+val filterTokensForAutocomplete = listOf(
+    context().getString(R.string.sort_title).lowercase() + ":"
+            to context().getString(R.string.sort_title),
+    context().getString(R.string.sort_artist).lowercase() + ":"
+            to context().getString(R.string.sort_artist),
+    context().getString(R.string.sort_album).lowercase() + ":"
+            to context().getString(R.string.sort_album),
+    context().getString(R.string.sort_year).lowercase() + ":"
+            to context().getString(R.string.sort_year),
+    context().getString(R.string.sort_duration).lowercase() + ":"
+            to context().getString(R.string.sort_duration),
+    context().getString(R.string.explicit).lowercase()
+            to context().getString(R.string.explicit),
+);
+
+var tokensCache: Pair<String, List<List<Token>>>? = null
+fun filterMediaMetadata(metadata: MediaMetadata, filter: String): Boolean {
+    val filterTrim = filter.trim()
+    if (filterTrim.isBlank()) return true // Default should let everything be shown.
+
+    // If in the cache, do not re parse the search query.
+    val tokenGroups: List<List<Token>> = when (tokensCache) {
+        null -> parseSearchQuery(filterTrim)
+        else -> when (tokensCache!!.first) {
+            filter -> tokensCache!!.second
+            else -> parseSearchQuery(filterTrim)
+        }
+    }
+    tokensCache = filter to tokenGroups
+
+    // Map labels to what the correspond to.
+    val metadataFields: Map<String, String> = mapOf(
+        context().getString(R.string.sort_title).lowercase() to (metadata.title.toString()),
+        context().getString(R.string.sort_artist).lowercase() to (metadata.artist.toString()),
+        context().getString(R.string.sort_duration).lowercase()
+                to (metadata.extras?.getString("durationText").toString()),
+        context().getString(R.string.sort_album).lowercase() to (metadata.albumTitle.toString()),
+        context().getString(R.string.sort_year).lowercase() to (metadata.releaseYear.toString()),
+    )
+
+    val included = tokenGroups.any { group -> // TODO slight bug with multiple exclusion tokens.
+        group.all { token ->
+            val searchFields = if (metadataFields.containsKey(token.field)) {
+                listOf(metadataFields[token.field] ?: "")
+            } else {
+                metadataFields.values
+            }
+            searchFields.any {
+                val groupApplies = when(token.valueType) {
+                    "IntRange" -> isWithinIntRange(it, token.value)
+                    "DurationRange" -> isWithinDurationRange(it, token.value)
+                    "ExplicitValue" -> metadata.extras?.getBoolean(EXPLICIT_BUNDLE_TAG)
+                    "BooleanValue" -> it.startsWith(token.value, ignoreCase = true) // Unused
+                    else -> it.contains(token.value, ignoreCase = true)
+                }
+                groupApplies == token.shouldInclude
+            }
+        }
+    }
+
+    return included
+}
+
+// Filter function for Song
+fun List<Song>.operatorFilterSong(filter: String): List<Song> {
+    return this.filter { it -> filterMediaMetadata(it.asMediaItem.mediaMetadata, filter) }
+}
+
+// Filter function for InnerTube.SongItem (used in playlists)
+fun List<SongItem>.operatorFilterSongItem(filter: String): List<SongItem> {
+    return this.filter { it -> filterMediaMetadata(it.asMediaItem.mediaMetadata, filter) }
+}
+
+// Filter function for SongEntity
+fun List<SongEntity>.operatorFilterSongEntity(filter: String): List<SongEntity> {
+    return this.filter { it -> filterMediaMetadata(it.asMediaItem.mediaMetadata, filter) }
+}
+
+// Filter function for Album
+fun List<Album>.operatorFilterAlbum(filter: String): List<Album> {
+    return this.filter { album ->
+        val metadata = MediaMetadata.Builder()
+            .setAlbumTitle(album.title)
+            .setArtist(album.authorsText)
+            .setReleaseYear(album.year?.toInt())
+            .build()
+        filterMediaMetadata(metadata, filter)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/OperatorFiltering.kt
@@ -2,7 +2,6 @@ package it.fast4x.rimusic.utils
 
 import androidx.media3.common.MediaMetadata
 import app.kreate.android.R
-import com.google.common.collect.Iterables.all
 import it.fast4x.innertube.Innertube.SongItem
 import it.fast4x.rimusic.context
 import it.fast4x.rimusic.models.Album
@@ -94,7 +93,7 @@ val filterTokensForAutocomplete = listOf(
             to context().getString(R.string.sort_duration),
     context().getString(R.string.explicit).lowercase()
             to context().getString(R.string.explicit),
-);
+)
 
 var tokensCache: Pair<String, List<List<Token>>>? = null
 fun filterMediaMetadata(metadata: MediaMetadata, filter: String): Boolean {

--- a/composeApp/src/androidMain/kotlin/me/knighthat/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/ui/screens/home/HomeSongs.kt
@@ -93,6 +93,7 @@ import it.fast4x.rimusic.utils.includeLocalSongsKey
 import it.fast4x.rimusic.utils.isDownloadedSong
 import it.fast4x.rimusic.utils.manageDownload
 import it.fast4x.rimusic.utils.onDeviceSongSortByKey
+import it.fast4x.rimusic.utils.operatorFilterSong
 import it.fast4x.rimusic.utils.parentalControlEnabledKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.semiBold
@@ -324,14 +325,7 @@ fun HomeSongs( navController: NavController ) {
     LaunchedEffect( items, search.input, currentPath ) {
         items.filter( ::naturalFilter )
              .filter { !parentalControlEnabled || !it.title.startsWith( EXPLICIT_PREFIX, true ) }
-             .filter {
-                 // Without cleaning, user can search explicit songs with "e:"
-                 // I kinda want this to be a feature, but it seems unnecessary
-                 val containsTitle = it.cleanTitle().contains( search.input, true )
-                 val containsArtist = it.artistsText?.contains( search.input, true ) ?: false
-
-                 containsTitle || containsArtist
-             }
+             .operatorFilterSong(search.input)
             .let {
                 itemsOnDisplay = it
 

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -955,4 +955,5 @@
     <string name="title_import_migration_file">Import migration file</string>
     <string name="description_import_migration_file">For old users before conversion. \nUse old app to make a backup for migration</string>
     <string name="description_app_not_installed_by_apk">App installed by an APK distributor should let its distributor update the app!</string>
+    <string name="or_operator">Or</string>
 </resources>


### PR DESCRIPTION
This moves all filtering logic for songs and albums to its own file. The filtering is also more than just string matching, including the ability to specify labels (album, artist, title, duration, explicit, etc), negation, and ORs. I wanted to finish this for RiMusic, but was unable to. 