### PR TITLE
Add missing translation variable for login prompt in HomeQuickPicks.kt

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeQuickPicks.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeQuickPicks.kt
@@ -1082,7 +1082,7 @@ fun HomeQuickPicks(
                         }
                     }
                 } ?: if (!isYouTubeLoggedIn()) BasicText(
-                    text = "Log in to your YTM account for more content",
+                    text = stringResource(R.string.log_in_to_ytm),
                     style = typography().xs.center,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -917,7 +917,7 @@
     <string name="please_wait">Please Wait</string>
     <string name="songs_liked_yt">Song(s) are Liked in YouTube</string>
     <string name="song_unliked_yt">Song is Unliked in YouTube</string>
-    <string name="add_rimusic_to_ytm_favorites">Like RiMusic Liked songs in Youtube</string>
+    <string name="add_rimusic_to_ytm_favorites">Like N-Zik Liked songs in Youtube</string>
     <string name="do_you_really_want_to_like_all_rimusictoytmusic">(estimated time) is required to like all the songs. This action cannot be resumed if cancelled in between. You need to close the app to cancel this process. Do you want to continue?</string>
     <string name="do_you_really_want_to_like_all">(estimated time) is required to like all the songs. You need to close the app to cancel this process. Do you want to continue?</string>
     <string name="songs_liked_yt_failed">Failed to like the song in YouTube</string>
@@ -964,4 +964,5 @@
     <string name="rotating_cover_title">Rotating album cover</string>
     <string name="title_playback_speed">Playback speed</string>
     <string name="description_playback_speed">Adjust how slow/fast the song goes</string>
+    <string name="log_in_to_ytm">Log in to your YTM account for more content</string>
 </resources>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -917,7 +917,7 @@
     <string name="please_wait">Please Wait</string>
     <string name="songs_liked_yt">Song(s) are Liked in YouTube</string>
     <string name="song_unliked_yt">Song is Unliked in YouTube</string>
-    <string name="add_rimusic_to_ytm_favorites">Like N-Zik Liked songs in Youtube</string>
+    <string name="add_rimusic_to_ytm_favorites">Like Kreate Liked songs in Youtube</string>
     <string name="do_you_really_want_to_like_all_rimusictoytmusic">(estimated time) is required to like all the songs. This action cannot be resumed if cancelled in between. You need to close the app to cancel this process. Do you want to continue?</string>
     <string name="do_you_really_want_to_like_all">(estimated time) is required to like all the songs. You need to close the app to cancel this process. Do you want to continue?</string>
     <string name="songs_liked_yt_failed">Failed to like the song in YouTube</string>


### PR DESCRIPTION
- Added <string name=\"log_in_to_ytm\">Log in to your YTM account for more content</string> in strings.xml
- Updated HomeQuickPicks.kt to use stringResource(R.string.log_in_to_ytm) for future translations