### PR TITLE
Improve note formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - Download songs or entire playlists for offline playback (not cache)
 - Background playback
 - Listening statistics
-- Audio visualizer on player with many type of effects $.^1$
+- Audio visualizer on player with many type of effects.¹
 - News, mood, musical genres, new albums from favourite artists
 - Import/Export online, RiMusic playlists, can be shared with friends
 - Fetch, display, edit, translate synchronized, or not, songs lyrics
@@ -47,11 +47,11 @@
 - Export cached/downloaded media
 - Export settings
 - Plays music even with no internet connection
-- Fully featured in-app update checker and auto-update $.^2$
+- Fully featured in-app update checker and auto-update.²
 
 > [!NOTE]
-> **¹.** This feature requires **microphone permission** (disabled by default)\
-> **².** This feature only available on GitHub builds (`Kreate-release.apk` and `Kreate-uncompressed.apk`)
+> **¹** This feature requires **microphone permission** (disabled by default)\
+> **²** This feature only available on GitHub builds (`Kreate-release.apk` and `Kreate-uncompressed.apk`)
 
 # Social media
 


### PR DESCRIPTION
Updated note formatting in README for clarity. This will now visible in both GitHub app and website because previously number were shown with signs which were used but now it will visible in both.
![Screenshot_2025-10-28-12-00-35-73_320a9a695de7cdce83ed5281148d6f19](https://github.com/user-attachments/assets/a7447cab-cde4-40ec-a162-9906cf80c23f)
