### PR TITLE
Add ability to export app data from app shortcut menu

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -147,7 +147,21 @@
         <activity
                 android:name=".CopyCrashlogActivity"
                 android:theme="@style/Theme.RiMusic"
-                android:exported="true" />
+                android:exported="true">
+            <intent-filter>
+                <action android:name="COPY_CRASH_LOG" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".ExportDatabaseActivity"
+            android:theme="@style/Theme.RiMusic"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="EXPORT_DATABASE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <receiver android:name=".widget.VerticalWidgetReceiver"
             android:exported="true">

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/ExportDatabaseActivity.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/ExportDatabaseActivity.kt
@@ -1,0 +1,64 @@
+package app.kreate.android
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import it.fast4x.rimusic.Database
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import me.knighthat.utils.TimeDateUtils
+import java.io.FileInputStream
+
+class ExportDatabaseActivity : AppCompatActivity() {
+
+    private val exportLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/vnd.sqlite3")
+    ) { uri ->
+        if (uri == null) {
+            finish()
+            return@registerForActivityResult
+        }
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                // Perform the copy operation in the background
+                applicationContext.contentResolver.openOutputStream(uri)?.use { outStream ->
+                    val dbFile = applicationContext.getDatabasePath(Database.FILE_NAME)
+                    FileInputStream(dbFile).use { inStream ->
+                        inStream.copyTo(outStream)
+                    }
+                }
+
+                // Optional: Show success message on Main thread
+                launch(Dispatchers.Main) {
+                    Toast.makeText(applicationContext, "Database exported!", Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                finish() // Close activity when done
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // 2. Prepare the database (checkpoint ensures all data is written to disk)
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                Database.checkpoint()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+
+            // 3. Launch the file picker (must be done on Main thread)
+            launch(Dispatchers.Main) {
+                // You can set a default filename here
+                exportLauncher.launch("${BuildConfig.APP_NAME}_database_${TimeDateUtils.localizedDateNoDelimiter()}_${TimeDateUtils.timeNoDelimiter()}")
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/res/xml-v25/shortcuts.xml
+++ b/composeApp/src/androidMain/res/xml-v25/shortcuts.xml
@@ -20,4 +20,14 @@
             android:targetPackage="me.knighthat.kreate"
             android:action="COPY_CRASH_LOG" />
     </shortcut>
+    <shortcut
+        android:shortcutId="databaseExport"
+        android:enabled="true"
+        android:icon="@drawable/open"
+        android:shortcutShortLabel="@string/export_the_database">
+        <intent
+            android:targetClass="app.kreate.android.ExportDatabaseActivity"
+            android:targetPackage="me.knighthat.kreate"
+            android:action="EXPORT_DATABASE" />
+    </shortcut>
 </shortcuts>


### PR DESCRIPTION
Add ability to export app data from app shortcut menu. It allows to backup data when it is not possible to do so when app crashes each time it opens, so it is not possible to export the data from settings menu. When fixing some bugs it helps to recover data after wiping app's data or reinstalling the app, since the data can be exported even if running the app is impossible.
Solves #1232.