### PR TITLE
fix queue not loading due to a missing index

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/kreate/android/service/player/StatefulPlayerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/service/player/StatefulPlayerImpl.kt
@@ -228,7 +228,7 @@ class StatefulPlayerImpl(private val player: ExoPlayer) :
                 return@launch
             }
 
-            val startIndex = queue.indexOfFirst { it.position != null }
+            val startIndex = queue.indexOfFirst { it.position != null }.coerceAtLeast( 0 )
             val startPositionMs = queue[startIndex].position ?: C.TIME_UNSET
             val mediaItems = withContext( Dispatchers.Default ) {
                 queue.map { queueItem ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
@@ -512,7 +512,7 @@ class MediaLibrarySessionCallback(
 
         scope.future {
             val queue = database.queueTable.blockingItems()
-            val startIndex = queue.indexOfFirst { it.position != null }
+            val startIndex = queue.indexOfFirst { it.position != null }.coerceAtLeast( 0 )
             val startPositionMs = queue[startIndex].position ?: C.TIME_UNSET
             val mediaItems = queue.map { it.song.asMediaItem.buildUpon().setTag( PersistentQueue.Tag ).build() }
             val resumptionPlaylist = MediaSession.MediaItemsWithStartPosition( mediaItems, startIndex, startPositionMs )


### PR DESCRIPTION
fix an issue where the app would crash due to a corruption in the `persistent_queue` table