### PR TITLE
Replace loadUrl("javascript:...") with evaluateJavascript in YouTubeLogin

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/youtubelogin/YouTubeLogin.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/youtubelogin/YouTubeLogin.kt
@@ -43,8 +43,8 @@ fun YouTubeLogin( onDone: () -> Unit ) {
             WebView(context).apply {
                 webViewClient = object : WebViewClient() {
                     override fun onPageFinished( view: WebView, url: String? ) {
-                        loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                        loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+                        view.evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
+                        view.evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
 
                         if ( url?.startsWith("https://music.youtube.com") == true ) {
                             Preferences.YOUTUBE_COOKIES.value = CookieManager.getInstance().getCookie( url )


### PR DESCRIPTION
Closes #1648

`YouTubeLogin.onPageFinished` injects two JS calls to read VISITOR_DATA and DATASYNC_ID back through the `Android` JS bridge using the legacy `loadUrl("javascript:...")` form:

```kotlin
loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
```

The Android docs deprecated that pattern in 4.4 in favour of `evaluateJavascript`. The legacy form adds a navigation entry to the WebView back/forward history on every `onPageFinished`, so flipping in and out of the login flow can leave the login URL stacked in history multiple times.

### Change

```kotlin
view.evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
view.evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
```

The `Android` JS bridge still receives the value the same way (the script calls it directly). Back stack stays clean.

The file header notes this is forked from Metrolist's `LoginScreen.kt`, so the same fix is worth carrying back upstream there.