### PR TITLE
feat: Share lyrics as video with audio

### DIFF
--- a/composeApp/src/androidGithub/kotlin/me/knighthat/updater/DownloadAndInstallDialog.kt
+++ b/composeApp/src/androidGithub/kotlin/me/knighthat/updater/DownloadAndInstallDialog.kt
@@ -78,7 +78,7 @@ object DownloadAndInstallDialog: Dialog {
         val apkUri = if(isAtLeastAndroid7 )
             FileProvider.getUriForFile(
                 context,
-                "${context.packageName}.provider", // must match manifest
+                "${context.packageName}.fileprovider", // must match manifest
                 apkFile
             )
         else

--- a/composeApp/src/androidGithub/res/xml/provider_paths.xml
+++ b/composeApp/src/androidGithub/res/xml/provider_paths.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths xmlns:tools="http://schemas.android.com/tools"
-        tools:keep="@xml/provider_paths">
-    <external-path name="external_files" path="." />
-</paths>

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -222,6 +222,16 @@
                 android:value="true" />
         </service>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <meta-data android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc"/>
 

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
@@ -1,0 +1,668 @@
+package app.kreate.android.screens.player
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.Typeface
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import app.kreate.android.R
+import app.kreate.android.coil3.ImageFactory
+import app.kreate.android.utils.blur
+import co.touchlab.kermit.Logger
+import it.fast4x.rimusic.colorPalette
+import it.fast4x.rimusic.typography
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import androidx.compose.ui.graphics.Color as ComposeColor
+
+private val logger = Logger.withTag("LyricsShareCard")
+
+/**
+ * Composable that provides a lyrics selection interface.
+ * Users can tap individual lines to select/deselect them.
+ *
+ * @param lyrics List of lyric lines to display for selection
+ * @param songTitle The title of the current song
+ * @param artistName The artist name
+ * @param thumbnailUrl URL of the song thumbnail/album art
+ * @param mediaId The song's media ID (used for YouTube link)
+ * @param currentPosition Current playback position in milliseconds
+ * @param onDismiss Callback when selection mode is dismissed
+ */
+@Composable
+fun LyricsSelectionMode(
+    lyrics: List<String>,
+    songTitle: String,
+    artistName: String,
+    thumbnailUrl: String?,
+    mediaId: String,
+    currentPosition: Long,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val selectedIndices = remember { mutableStateListOf<Int>() }
+    var isGenerating by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        // Header with instructions and action buttons
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BasicText(
+                text = stringResource(R.string.lyrics_share_select_lines),
+                style = typography().xs.copy(
+                    color = ComposeColor.White,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Cancel button
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(ComposeColor.White.copy(alpha = 0.2f))
+                        .clickable { onDismiss() }
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                ) {
+                    BasicText(
+                        text = stringResource(R.string.cancel),
+                        style = typography().xxs.copy(
+                            color = ComposeColor.White
+                        )
+                    )
+                }
+
+                // Share button (appears when lines are selected)
+                AnimatedVisibility(
+                    visible = selectedIndices.isNotEmpty(),
+                    enter = fadeIn() + slideInVertically(),
+                    exit = fadeOut() + slideOutVertically()
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(colorPalette().accent)
+                            .clickable(enabled = !isGenerating) {
+                                coroutineScope.launch {
+                                    isGenerating = true
+                                    val selectedLines = selectedIndices
+                                        .sorted()
+                                        .map { lyrics[it] }
+                                    generateAndShareLyricsCard(
+                                        context = context,
+                                        selectedLyrics = selectedLines,
+                                        songTitle = songTitle,
+                                        artistName = artistName,
+                                        thumbnailUrl = thumbnailUrl,
+                                        mediaId = mediaId,
+                                        currentPosition = currentPosition
+                                    )
+                                    isGenerating = false
+                                    onDismiss()
+                                }
+                            }
+                            .padding(horizontal = 12.dp, vertical = 6.dp)
+                    ) {
+                        if (isGenerating) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(14.dp),
+                                color = ComposeColor.White,
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            BasicText(
+                                text = stringResource(R.string.lyrics_share_create_card),
+                                style = typography().xxs.copy(
+                                    color = ComposeColor.White,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Selected count indicator
+        if (selectedIndices.isNotEmpty()) {
+            BasicText(
+                text = "${selectedIndices.size} line${if (selectedIndices.size > 1) "s" else ""} selected",
+                style = typography().xxs.copy(
+                    color = colorPalette().accent
+                ),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        // Lyrics selection list
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            itemsIndexed(lyrics) { index, line ->
+                if (line.isBlank()) return@itemsIndexed
+
+                val isSelected = index in selectedIndices
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(
+                            if (isSelected) colorPalette().accent.copy(alpha = 0.3f)
+                            else ComposeColor.White.copy(alpha = 0.05f)
+                        )
+                        .then(
+                            if (isSelected) Modifier.border(
+                                width = 1.dp,
+                                color = colorPalette().accent,
+                                shape = RoundedCornerShape(8.dp)
+                            ) else Modifier
+                        )
+                        .clickable {
+                            if (isSelected) {
+                                selectedIndices.remove(index)
+                            } else {
+                                selectedIndices.add(index)
+                            }
+                        }
+                        .padding(horizontal = 12.dp, vertical = 10.dp)
+                ) {
+                    BasicText(
+                        text = line,
+                        style = typography().s.copy(
+                            color = if (isSelected) ComposeColor.White
+                            else ComposeColor.White.copy(alpha = 0.7f),
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                            textAlign = TextAlign.Center
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Generates a lyrics image card and shares it via Android's share intent.
+ *
+ * The image card features:
+ * - Blurred album art background
+ * - Gradient overlay for readability
+ * - Selected lyrics text
+ * - Song title and artist
+ * - App branding
+ * - Optional link to the song
+ */
+suspend fun generateAndShareLyricsCard(
+    context: Context,
+    selectedLyrics: List<String>,
+    songTitle: String,
+    artistName: String,
+    thumbnailUrl: String?,
+    mediaId: String,
+    currentPosition: Long
+) {
+    withContext(Dispatchers.IO) {
+        try {
+            val cardBitmap = createLyricsCardBitmap(
+                context = context,
+                lyrics = selectedLyrics,
+                songTitle = songTitle,
+                artistName = artistName,
+                thumbnailUrl = thumbnailUrl
+            )
+
+            // Save the bitmap to a temp file
+            val shareDir = File(context.cacheDir, "shared_lyrics")
+            shareDir.mkdirs()
+            val imageFile = File(shareDir, "lyrics_card_${System.currentTimeMillis()}.png")
+            FileOutputStream(imageFile).use { stream ->
+                cardBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+            }
+
+            // Get content URI via FileProvider
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                imageFile
+            )
+
+            // Build share text with optional music link
+            val shareText = buildString {
+                append("\"${selectedLyrics.joinToString("\n")}\"")
+                append("\n\n— $songTitle by $artistName")
+                append("\n\n🎵 https://music.youtube.com/watch?v=$mediaId")
+                if (currentPosition > 0) {
+                    val seconds = (currentPosition / 1000).toInt()
+                    append("&t=${seconds}s")
+                }
+            }
+
+            // Launch share intent
+            withContext(Dispatchers.Main) {
+                val shareIntent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    type = "image/png"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    putExtra(Intent.EXTRA_TEXT, shareText)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                context.startActivity(
+                    Intent.createChooser(shareIntent, null)
+                )
+            }
+        } catch (e: Exception) {
+            logger.e(e) { "Failed to generate/share lyrics card" }
+        }
+    }
+}
+
+/**
+ * Creates a Bitmap of the lyrics card using Android Canvas.
+ *
+ * Design: Modern card with full-bleed blurred background, strong dark gradient,
+ * app icon at top-left, lyrics as main content in the center,
+ * and small album art beside song title/artist at the bottom.
+ * Height is dynamic based on content.
+ */
+private suspend fun createLyricsCardBitmap(
+    context: Context,
+    lyrics: List<String>,
+    songTitle: String,
+    artistName: String,
+    thumbnailUrl: String?
+): Bitmap {
+    val cardWidth = 1080
+    val padding = 80f
+    val topBarHeight = 100f      // space for app icon row
+    val bottomInfoHeight = 140f  // space for album art + song info row
+    val bottomPadding = 80f
+
+    // Measure lyrics text height to calculate dynamic card height
+    val lyricsPaint = TextPaint().apply {
+        color = Color.WHITE
+        textSize = 58f
+        isAntiAlias = true
+        typeface = Typeface.create("sans-serif-medium", Typeface.BOLD)
+        textAlign = Paint.Align.CENTER
+        letterSpacing = 0.01f
+    }
+    val lyricsText = lyrics.joinToString("\n")
+    val textWidth = (cardWidth - padding * 2).toInt()
+    val lyricsLayout = StaticLayout.Builder
+        .obtain(lyricsText, 0, lyricsText.length, lyricsPaint, textWidth)
+        .setAlignment(Layout.Alignment.ALIGN_CENTER)
+        .setLineSpacing(24f, 1.3f)
+        .setIncludePad(true)
+        .build()
+    val lyricsHeight = lyricsLayout.height.toFloat()
+
+    // Calculate total card height: padding + top bar + gap + lyrics + gap + bottom info + padding
+    val cardHeight = (padding + topBarHeight + 60f + lyricsHeight + 80f
+            + bottomInfoHeight + bottomPadding).toInt()
+        .coerceIn(800, 1920)
+
+    val bitmap = Bitmap.createBitmap(cardWidth, cardHeight, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    // Load album art once and reuse
+    val albumArt = thumbnailUrl?.let {
+        try {
+            val hiResUrl = it.replace(Regex("=w\\d+-h\\d+"), "=w800-h800")
+            ImageFactory.bitmap(hiResUrl).getOrNull()?.let { bmp ->
+                if (bmp.config == Bitmap.Config.HARDWARE) {
+                    bmp.copy(Bitmap.Config.ARGB_8888, true).also { bmp.recycle() }
+                } else bmp
+            }
+        } catch (e: Exception) {
+            logger.w(e) { "Failed to load thumbnail for lyrics card" }
+            null
+        }
+    }
+
+    // 1. Draw full-bleed blurred background
+    drawBackground(canvas, cardWidth, cardHeight, albumArt)
+
+    // 2. Draw strong gradient overlay
+    drawGradientOverlay(canvas, cardWidth, cardHeight)
+
+    // 3. Draw app icon at top-left
+    drawAppIcon(context, canvas, padding)
+
+    // 4. Draw lyrics text (centered in the main area)
+    val lyricsStartY = padding + topBarHeight + 60f
+    drawLyricsText(canvas, lyricsLayout, cardWidth, lyricsStartY, padding)
+
+    // 5. Draw song info row at bottom (album art thumbnail + title + artist)
+    drawSongInfoRow(canvas, songTitle, artistName, albumArt, cardWidth, cardHeight, padding)
+
+    return bitmap
+}
+
+private suspend fun drawBackground(
+    canvas: Canvas,
+    width: Int,
+    height: Int,
+    albumArt: Bitmap?
+) {
+    if (albumArt != null) {
+        // Scale album art to cover the entire card (center-crop)
+        val srcRatio = albumArt.width.toFloat() / albumArt.height.toFloat()
+        val dstRatio = width.toFloat() / height.toFloat()
+
+        val scaled = if (srcRatio > dstRatio) {
+            // Source is wider — fit height, crop width
+            val scaledWidth = (height * srcRatio).toInt()
+            Bitmap.createScaledBitmap(albumArt, scaledWidth, height, true)
+        } else {
+            // Source is taller — fit width, crop height
+            val scaledHeight = (width / srcRatio).toInt()
+            Bitmap.createScaledBitmap(albumArt, width, scaledHeight, true)
+        }
+
+        // Center crop
+        val cropX = ((scaled.width - width) / 2).coerceAtLeast(0)
+        val cropY = ((scaled.height - height) / 2).coerceAtLeast(0)
+        val cropped = Bitmap.createBitmap(
+            scaled, cropX, cropY,
+            width.coerceAtMost(scaled.width - cropX),
+            height.coerceAtMost(scaled.height - cropY)
+        )
+
+        // Heavy blur for background
+        val blurred = cropped.blur(0.5f, 25)
+        canvas.drawBitmap(
+            Bitmap.createScaledBitmap(blurred, width, height, true),
+            0f, 0f, null
+        )
+        blurred.recycle()
+        if (cropped !== scaled) cropped.recycle()
+        scaled.recycle()
+    } else {
+        // Fallback: rich dark gradient
+        val bgPaint = Paint().apply {
+            shader = LinearGradient(
+                0f, 0f, width.toFloat(), height.toFloat(),
+                Color.parseColor("#0f0c29"),
+                Color.parseColor("#302b63"),
+                Shader.TileMode.CLAMP
+            )
+        }
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), bgPaint)
+    }
+}
+
+private fun drawGradientOverlay(canvas: Canvas, width: Int, height: Int) {
+    // Strong vignette-like overlay: dark at top and bottom, slightly lighter in the middle
+    val overlayPaint = Paint().apply {
+        shader = LinearGradient(
+            0f, 0f, 0f, height.toFloat(),
+            intArrayOf(
+                Color.argb(200, 0, 0, 0),   // top: very dark
+                Color.argb(120, 0, 0, 0),   // upper middle
+                Color.argb(100, 0, 0, 0),   // center
+                Color.argb(140, 0, 0, 0),   // lower middle
+                Color.argb(230, 0, 0, 0)    // bottom: very dark
+            ),
+            floatArrayOf(0f, 0.25f, 0.45f, 0.7f, 1f),
+            Shader.TileMode.CLAMP
+        )
+    }
+    canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), overlayPaint)
+}
+
+/**
+ * Draws the app icon at the top-left corner of the card.
+ */
+private fun drawAppIcon(
+    context: Context,
+    canvas: Canvas,
+    padding: Float
+) {
+    val iconSize = 72f
+    val iconTop = padding
+    val iconLeft = padding
+
+    try {
+        val iconDrawable = context.packageManager.getApplicationIcon(context.packageName)
+        val iconBitmap = Bitmap.createBitmap(iconSize.toInt(), iconSize.toInt(), Bitmap.Config.ARGB_8888)
+        val iconCanvas = Canvas(iconBitmap)
+        iconDrawable.setBounds(0, 0, iconSize.toInt(), iconSize.toInt())
+        iconDrawable.draw(iconCanvas)
+
+        // Draw with circular clipping
+        val path = android.graphics.Path().apply {
+            addCircle(
+                iconLeft + iconSize / 2f,
+                iconTop + iconSize / 2f,
+                iconSize / 2f,
+                android.graphics.Path.Direction.CW
+            )
+        }
+        canvas.save()
+        canvas.clipPath(path)
+        canvas.drawBitmap(iconBitmap, iconLeft, iconTop, null)
+        canvas.restore()
+        iconBitmap.recycle()
+    } catch (e: Exception) {
+        // Fallback: draw a simple circle with "K"
+        val circlePaint = Paint().apply {
+            color = Color.argb(80, 255, 255, 255)
+            isAntiAlias = true
+        }
+        canvas.drawCircle(iconLeft + iconSize / 2f, iconTop + iconSize / 2f, iconSize / 2f, circlePaint)
+
+        val textPaint = TextPaint().apply {
+            color = Color.WHITE
+            textSize = 36f
+            isAntiAlias = true
+            textAlign = Paint.Align.CENTER
+            typeface = Typeface.create("sans-serif-medium", Typeface.BOLD)
+        }
+        canvas.drawText("K", iconLeft + iconSize / 2f, iconTop + iconSize / 2f + 12f, textPaint)
+    }
+}
+
+private fun drawLyricsText(
+    canvas: Canvas,
+    lyricsLayout: StaticLayout,
+    width: Int,
+    startY: Float,
+    padding: Float
+) {
+    // Draw a subtle quote decoration
+    val quotePaint = TextPaint().apply {
+        color = Color.argb(40, 255, 255, 255)
+        textSize = 140f
+        isAntiAlias = true
+        typeface = Typeface.create("serif", Typeface.ITALIC)
+        textAlign = Paint.Align.LEFT
+    }
+    canvas.drawText("\u201C", padding - 20f, startY + 70f, quotePaint)
+
+    canvas.save()
+    canvas.translate(width / 2f, startY)
+    lyricsLayout.draw(canvas)
+    canvas.restore()
+}
+
+/**
+ * Draws a bottom row with: [album art thumbnail] [song title / artist name]
+ */
+private fun drawSongInfoRow(
+    canvas: Canvas,
+    songTitle: String,
+    artistName: String,
+    albumArt: Bitmap?,
+    width: Int,
+    height: Int,
+    padding: Float
+) {
+    val thumbSize = 96f
+    val cornerRadius = 16f
+    val rowY = height - padding - thumbSize  // vertically position the row
+    val thumbLeft = padding
+    val textLeft = thumbLeft + thumbSize + 24f
+
+    // Draw small album art thumbnail
+    if (albumArt != null) {
+        val scaledArt = Bitmap.createScaledBitmap(albumArt, thumbSize.toInt(), thumbSize.toInt(), true)
+
+        val path = android.graphics.Path().apply {
+            addRoundRect(
+                RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+                cornerRadius, cornerRadius,
+                android.graphics.Path.Direction.CW
+            )
+        }
+        canvas.save()
+        canvas.clipPath(path)
+        canvas.drawBitmap(scaledArt, thumbLeft, rowY, null)
+        canvas.restore()
+        scaledArt.recycle()
+
+        // Subtle border
+        val borderPaint = Paint().apply {
+            style = Paint.Style.STROKE
+            color = Color.argb(50, 255, 255, 255)
+            strokeWidth = 2f
+            isAntiAlias = true
+        }
+        canvas.drawRoundRect(
+            RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+            cornerRadius, cornerRadius, borderPaint
+        )
+    } else {
+        // Placeholder
+        val placeholderPaint = Paint().apply {
+            color = Color.argb(40, 255, 255, 255)
+            isAntiAlias = true
+        }
+        canvas.drawRoundRect(
+            RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+            cornerRadius, cornerRadius, placeholderPaint
+        )
+        val notePaint = TextPaint().apply {
+            color = Color.argb(100, 255, 255, 255)
+            textSize = 40f
+            isAntiAlias = true
+            textAlign = Paint.Align.CENTER
+        }
+        canvas.drawText("♪", thumbLeft + thumbSize / 2f, rowY + thumbSize / 2f + 14f, notePaint)
+    }
+
+    // Song title (to the right of thumbnail, vertically centered)
+    val titlePaint = TextPaint().apply {
+        color = Color.WHITE
+        textSize = 38f
+        isAntiAlias = true
+        typeface = Typeface.create("sans-serif-medium", Typeface.BOLD)
+        textAlign = Paint.Align.LEFT
+    }
+
+    val maxTextWidth = width - textLeft - padding
+    val displayTitle = if (titlePaint.measureText(songTitle) > maxTextWidth) {
+        var truncated = songTitle
+        while (titlePaint.measureText("$truncated…") > maxTextWidth && truncated.isNotEmpty()) {
+            truncated = truncated.dropLast(1)
+        }
+        "$truncated…"
+    } else songTitle
+
+    val titleY = rowY + thumbSize / 2f - 8f
+    canvas.drawText(displayTitle, textLeft, titleY, titlePaint)
+
+    // Artist name (below title)
+    val artistPaint = TextPaint().apply {
+        color = Color.argb(160, 255, 255, 255)
+        textSize = 32f
+        isAntiAlias = true
+        typeface = Typeface.create("sans-serif", Typeface.NORMAL)
+        textAlign = Paint.Align.LEFT
+    }
+    canvas.drawText(artistName, textLeft, titleY + 42f, artistPaint)
+}
+
+/**
+ * Parses synced lyrics text (LRC format) into a list of plain text lines.
+ * Removes timestamps like [00:12.34] from each line.
+ */
+fun parseLyricsToLines(text: String?, isSynced: Boolean): List<String> {
+    if (text.isNullOrBlank()) return emptyList()
+
+    return if (isSynced) {
+        text.lines()
+            .map { line -> line.replace(Regex("\\[\\d{2}:\\d{2}\\.\\d{2,3}]"), "").trim() }
+            .filter { it.isNotBlank() }
+    } else {
+        text.lines().filter { it.isNotBlank() }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
@@ -70,6 +70,7 @@ private val logger = Logger.withTag("LyricsShareCard")
 /**
  * Composable that provides a lyrics selection interface.
  * Users can tap individual lines to select/deselect them.
+ * Supports sharing as image card or video with audio.
  *
  * @param lyrics List of lyric lines to display for selection
  * @param songTitle The title of the current song
@@ -77,6 +78,7 @@ private val logger = Logger.withTag("LyricsShareCard")
  * @param thumbnailUrl URL of the song thumbnail/album art
  * @param mediaId The song's media ID (used for YouTube link)
  * @param currentPosition Current playback position in milliseconds
+ * @param syncedLyricsText Raw LRC text with timestamps (null if lyrics aren't synced)
  * @param onDismiss Callback when selection mode is dismissed
  */
 @Composable
@@ -87,12 +89,21 @@ fun LyricsSelectionMode(
     thumbnailUrl: String?,
     mediaId: String,
     currentPosition: Long,
+    syncedLyricsText: String? = null,
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var isGenerating by remember { mutableStateOf(false) }
+    var shareAsVideo by remember { mutableStateOf(false) }
+
+    // Parse timestamps from synced lyrics for video mode
+    val lyricsWithTimestamps: List<Pair<Long, String>> = remember(syncedLyricsText) {
+        if (syncedLyricsText == null) emptyList()
+        else it.fast4x.lrclib.LrcLib.Lyrics(syncedLyricsText).sentences
+    }
+    val isSyncAvailable = lyricsWithTimestamps.isNotEmpty()
 
     Column(
         modifier = Modifier
@@ -148,18 +159,31 @@ fun LyricsSelectionMode(
                             .clickable(enabled = !isGenerating) {
                                 coroutineScope.launch {
                                     isGenerating = true
-                                    val selectedLines = selectedIndices
-                                        .sorted()
-                                        .map { lyrics[it] }
-                                    generateAndShareLyricsCard(
-                                        context = context,
-                                        selectedLyrics = selectedLines,
-                                        songTitle = songTitle,
-                                        artistName = artistName,
-                                        thumbnailUrl = thumbnailUrl,
-                                        mediaId = mediaId,
-                                        currentPosition = currentPosition
-                                    )
+                                    val sortedIndices = selectedIndices.sorted()
+                                    val selectedLines = sortedIndices.map { lyrics[it] }
+
+                                    if (shareAsVideo && isSyncAvailable) {
+                                        generateAndShareLyricsVideo(
+                                            context = context,
+                                            selectedLyrics = selectedLines,
+                                            songTitle = songTitle,
+                                            artistName = artistName,
+                                            thumbnailUrl = thumbnailUrl,
+                                            mediaId = mediaId,
+                                            lyricsWithTimestamps = lyricsWithTimestamps,
+                                            selectedIndices = sortedIndices
+                                        )
+                                    } else {
+                                        generateAndShareLyricsCard(
+                                            context = context,
+                                            selectedLyrics = selectedLines,
+                                            songTitle = songTitle,
+                                            artistName = artistName,
+                                            thumbnailUrl = thumbnailUrl,
+                                            mediaId = mediaId,
+                                            currentPosition = currentPosition
+                                        )
+                                    }
                                     isGenerating = false
                                     onDismiss()
                                 }
@@ -174,7 +198,8 @@ fun LyricsSelectionMode(
                             )
                         } else {
                             BasicText(
-                                text = stringResource(R.string.lyrics_share_create_card),
+                                text = if (shareAsVideo) stringResource(R.string.lyrics_share_create_video)
+                                       else stringResource(R.string.lyrics_share_create_card),
                                 style = typography().xxs.copy(
                                     color = ComposeColor.White,
                                     fontWeight = FontWeight.Bold
@@ -186,7 +211,56 @@ fun LyricsSelectionMode(
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Image / Video toggle (only show if synced lyrics available)
+        if (isSyncAvailable) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Image mode pill
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(
+                            if (!shareAsVideo) colorPalette().accent.copy(alpha = 0.8f)
+                            else ComposeColor.White.copy(alpha = 0.1f)
+                        )
+                        .clickable { shareAsVideo = false }
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    BasicText(
+                        text = "📷 ${stringResource(R.string.lyrics_share_mode_image)}",
+                        style = typography().xxs.copy(
+                            color = ComposeColor.White,
+                            fontWeight = if (!shareAsVideo) FontWeight.Bold else FontWeight.Normal
+                        )
+                    )
+                }
+                // Video mode pill
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(
+                            if (shareAsVideo) colorPalette().accent.copy(alpha = 0.8f)
+                            else ComposeColor.White.copy(alpha = 0.1f)
+                        )
+                        .clickable { shareAsVideo = true }
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    BasicText(
+                        text = "🎬 ${stringResource(R.string.lyrics_share_mode_video)}",
+                        style = typography().xxs.copy(
+                            color = ComposeColor.White,
+                            fontWeight = if (shareAsVideo) FontWeight.Bold else FontWeight.Normal
+                        )
+                    )
+                }
+            }
+        }
 
         // Selected count indicator
         if (selectedIndices.isNotEmpty()) {
@@ -313,14 +387,146 @@ suspend fun generateAndShareLyricsCard(
                     type = "image/png"
                     putExtra(Intent.EXTRA_STREAM, uri)
                     putExtra(Intent.EXTRA_TEXT, shareText)
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    clipData = android.content.ClipData.newRawUri(null, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
-                context.startActivity(
-                    Intent.createChooser(shareIntent, null)
-                )
+                context.startActivity(Intent.createChooser(shareIntent, null))
             }
         } catch (e: Exception) {
             logger.e(e) { "Failed to generate/share lyrics card" }
+        }
+    }
+}
+
+/**
+ * Generates a lyrics video (MP4) with audio from the song and shares it.
+ *
+ * Uses the synced lyrics timestamps to determine the audio segment,
+ * renders the lyrics card as a static video frame, and muxes with the audio.
+ */
+suspend fun generateAndShareLyricsVideo(
+    context: Context,
+    selectedLyrics: List<String>,
+    songTitle: String,
+    artistName: String,
+    thumbnailUrl: String?,
+    mediaId: String,
+    lyricsWithTimestamps: List<Pair<Long, String>>,
+    selectedIndices: List<Int>
+) {
+    withContext(Dispatchers.IO) {
+        try {
+            // Determine audio start/end from synced lyrics timestamps.
+            // lyricsWithTimestamps includes the initial (0, "") entry at index 0.
+            // Parsed plain lyrics (without blanks) correspond to entries starting at index 1.
+            val firstSelectedIdx = selectedIndices.first()
+            val lastSelectedIdx = selectedIndices.last()
+
+            val startTimestampIdx = (firstSelectedIdx + 1).coerceIn(0, lyricsWithTimestamps.lastIndex)
+            val endTimestampIdx = (lastSelectedIdx + 2).coerceIn(0, lyricsWithTimestamps.lastIndex)
+
+            val startMs = lyricsWithTimestamps[startTimestampIdx].first
+            val endMs = if (endTimestampIdx <= lyricsWithTimestamps.lastIndex) {
+                lyricsWithTimestamps[endTimestampIdx].first
+            } else {
+                // Last line: add 5 seconds after it starts
+                lyricsWithTimestamps.last().first + 5000L
+            }
+
+            if (endMs <= startMs) {
+                logger.e { "Invalid time range: start=$startMs, end=$endMs" }
+                return@withContext
+            }
+
+            // Extract audio segment from cache
+            val cache: androidx.media3.datasource.cache.Cache by org.koin.java.KoinJavaComponent.inject(
+                androidx.media3.datasource.cache.Cache::class.java, app.kreate.di.CacheType.CACHE
+            )
+            val downloadCache: androidx.media3.datasource.cache.Cache by org.koin.java.KoinJavaComponent.inject(
+                androidx.media3.datasource.cache.Cache::class.java, app.kreate.di.CacheType.DOWNLOAD
+            )
+
+            val audioFile = app.kreate.android.screens.player.share.extractAudioSegment(
+                context = context,
+                songId = mediaId,
+                cache = cache,
+                downloadCache = downloadCache,
+                startMs = startMs,
+                endMs = endMs
+            )
+
+            if (audioFile == null) {
+                logger.e { "Failed to extract audio segment. Song may not be cached." }
+                // Fall back to image share
+                generateAndShareLyricsCard(
+                    context, selectedLyrics, songTitle, artistName,
+                    thumbnailUrl, mediaId, startMs
+                )
+                return@withContext
+            }
+
+            // Generate the lyrics card bitmap
+            val cardBitmap = createLyricsCardBitmap(
+                context = context,
+                lyrics = selectedLyrics,
+                songTitle = songTitle,
+                artistName = artistName,
+                thumbnailUrl = thumbnailUrl
+            )
+
+            // Encode video
+            val shareDir = File(context.cacheDir, "shared_lyrics")
+            shareDir.mkdirs()
+            val videoFile = File(shareDir, "lyrics_video_${System.currentTimeMillis()}.mp4")
+            val durationMs = endMs - startMs
+
+            val success = app.kreate.android.screens.player.share.encodeLyricsVideo(
+                cardBitmap = cardBitmap,
+                audioFile = audioFile,
+                outputFile = videoFile,
+                durationMs = durationMs
+            )
+
+            // Clean up audio temp file
+            audioFile.delete()
+
+            if (!success) {
+                logger.e { "Video encoding failed, falling back to image share" }
+                generateAndShareLyricsCard(
+                    context, selectedLyrics, songTitle, artistName,
+                    thumbnailUrl, mediaId, startMs
+                )
+                return@withContext
+            }
+
+            // Share the video
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                videoFile
+            )
+
+            val shareText = buildString {
+                append("\"${selectedLyrics.joinToString("\n")}\"")
+                append("\n\n— $songTitle by $artistName")
+                append("\n\n🎵 https://music.youtube.com/watch?v=$mediaId")
+                val seconds = (startMs / 1000).toInt()
+                if (seconds > 0) append("&t=${seconds}s")
+            }
+
+            withContext(Dispatchers.Main) {
+                val shareIntent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    type = "video/mp4"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    putExtra(Intent.EXTRA_TEXT, shareText)
+                    clipData = android.content.ClipData.newRawUri(null, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(Intent.createChooser(shareIntent, null))
+            }
+        } catch (e: Exception) {
+            logger.e(e) { "Failed to generate/share lyrics video" }
         }
     }
 }
@@ -378,9 +584,9 @@ private suspend fun createLyricsCardBitmap(
         try {
             val hiResUrl = it.replace(Regex("=w\\d+-h\\d+"), "=w800-h800")
             ImageFactory.bitmap(hiResUrl).getOrNull()?.let { bmp ->
-                if (bmp.config == Bitmap.Config.HARDWARE) {
-                    bmp.copy(Bitmap.Config.ARGB_8888, true).also { bmp.recycle() }
-                } else bmp
+                // Always copy to a mutable software bitmap.
+                // Don't recycle the original — Coil's memory cache owns it.
+                bmp.copy(Bitmap.Config.ARGB_8888, true)
             }
         } catch (e: Exception) {
             logger.w(e) { "Failed to load thumbnail for lyrics card" }

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/LyricsShareCard.kt
@@ -96,7 +96,8 @@ fun LyricsSelectionMode(
     val coroutineScope = rememberCoroutineScope()
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var isGenerating by remember { mutableStateOf(false) }
-    var shareAsVideo by remember { mutableStateOf(false) }
+    // 0 = Image, 1 = Video (static), 2 = Animated Video
+    var shareMode by remember { mutableStateOf(0) }
 
     // Parse timestamps from synced lyrics for video mode
     val lyricsWithTimestamps: List<Pair<Long, String>> = remember(syncedLyricsText) {
@@ -162,7 +163,7 @@ fun LyricsSelectionMode(
                                     val sortedIndices = selectedIndices.sorted()
                                     val selectedLines = sortedIndices.map { lyrics[it] }
 
-                                    if (shareAsVideo && isSyncAvailable) {
+                                    if (shareMode != 0 && isSyncAvailable) {
                                         generateAndShareLyricsVideo(
                                             context = context,
                                             selectedLyrics = selectedLines,
@@ -171,7 +172,8 @@ fun LyricsSelectionMode(
                                             thumbnailUrl = thumbnailUrl,
                                             mediaId = mediaId,
                                             lyricsWithTimestamps = lyricsWithTimestamps,
-                                            selectedIndices = sortedIndices
+                                            selectedIndices = sortedIndices,
+                                            animated = shareMode == 2
                                         )
                                     } else {
                                         generateAndShareLyricsCard(
@@ -198,8 +200,10 @@ fun LyricsSelectionMode(
                             )
                         } else {
                             BasicText(
-                                text = if (shareAsVideo) stringResource(R.string.lyrics_share_create_video)
-                                       else stringResource(R.string.lyrics_share_create_card),
+                                text = when (shareMode) {
+                                    0 -> stringResource(R.string.lyrics_share_create_card)
+                                    else -> stringResource(R.string.lyrics_share_create_video)
+                                },
                                 style = typography().xxs.copy(
                                     color = ComposeColor.White,
                                     fontWeight = FontWeight.Bold
@@ -213,7 +217,7 @@ fun LyricsSelectionMode(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        // Image / Video toggle (only show if synced lyrics available)
+        // Image / Video / Animated toggle (only show if synced lyrics available)
         if (isSyncAvailable) {
             Row(
                 modifier = Modifier
@@ -226,36 +230,55 @@ fun LyricsSelectionMode(
                     modifier = Modifier
                         .clip(RoundedCornerShape(12.dp))
                         .background(
-                            if (!shareAsVideo) colorPalette().accent.copy(alpha = 0.8f)
+                            if (shareMode == 0) colorPalette().accent.copy(alpha = 0.8f)
                             else ComposeColor.White.copy(alpha = 0.1f)
                         )
-                        .clickable { shareAsVideo = false }
+                        .clickable { shareMode = 0 }
                         .padding(horizontal = 14.dp, vertical = 6.dp)
                 ) {
                     BasicText(
                         text = "📷 ${stringResource(R.string.lyrics_share_mode_image)}",
                         style = typography().xxs.copy(
                             color = ComposeColor.White,
-                            fontWeight = if (!shareAsVideo) FontWeight.Bold else FontWeight.Normal
+                            fontWeight = if (shareMode == 0) FontWeight.Bold else FontWeight.Normal
                         )
                     )
                 }
-                // Video mode pill
+                // Video (static) mode pill
                 Box(
                     modifier = Modifier
                         .clip(RoundedCornerShape(12.dp))
                         .background(
-                            if (shareAsVideo) colorPalette().accent.copy(alpha = 0.8f)
+                            if (shareMode == 1) colorPalette().accent.copy(alpha = 0.8f)
                             else ComposeColor.White.copy(alpha = 0.1f)
                         )
-                        .clickable { shareAsVideo = true }
+                        .clickable { shareMode = 1 }
                         .padding(horizontal = 14.dp, vertical = 6.dp)
                 ) {
                     BasicText(
                         text = "🎬 ${stringResource(R.string.lyrics_share_mode_video)}",
                         style = typography().xxs.copy(
                             color = ComposeColor.White,
-                            fontWeight = if (shareAsVideo) FontWeight.Bold else FontWeight.Normal
+                            fontWeight = if (shareMode == 1) FontWeight.Bold else FontWeight.Normal
+                        )
+                    )
+                }
+                // Animated video mode pill
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(
+                            if (shareMode == 2) colorPalette().accent.copy(alpha = 0.8f)
+                            else ComposeColor.White.copy(alpha = 0.1f)
+                        )
+                        .clickable { shareMode = 2 }
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    BasicText(
+                        text = "✨ ${stringResource(R.string.lyrics_share_mode_animated)}",
+                        style = typography().xxs.copy(
+                            color = ComposeColor.White,
+                            fontWeight = if (shareMode == 2) FontWeight.Bold else FontWeight.Normal
                         )
                     )
                 }
@@ -412,7 +435,8 @@ suspend fun generateAndShareLyricsVideo(
     thumbnailUrl: String?,
     mediaId: String,
     lyricsWithTimestamps: List<Pair<Long, String>>,
-    selectedIndices: List<Int>
+    selectedIndices: List<Int>,
+    animated: Boolean = true
 ) {
     withContext(Dispatchers.IO) {
         try {
@@ -465,14 +489,17 @@ suspend fun generateAndShareLyricsVideo(
                 return@withContext
             }
 
-            // Generate the lyrics card bitmap
-            val cardBitmap = createLyricsCardBitmap(
-                context = context,
-                lyrics = selectedLyrics,
-                songTitle = songTitle,
-                artistName = artistName,
-                thumbnailUrl = thumbnailUrl
-            )
+            // Load album art
+            val albumArt = thumbnailUrl?.let {
+                try {
+                    val hiResUrl = it.replace(Regex("=w\\d+-h\\d+"), "=w800-h800")
+                    app.kreate.android.coil3.ImageFactory.bitmap(hiResUrl).getOrNull()?.let { bmp ->
+                        bmp.copy(Bitmap.Config.ARGB_8888, true)
+                    }
+                } catch (e: Exception) {
+                    null
+                }
+            }
 
             // Encode video
             val shareDir = File(context.cacheDir, "shared_lyrics")
@@ -480,12 +507,50 @@ suspend fun generateAndShareLyricsVideo(
             val videoFile = File(shareDir, "lyrics_video_${System.currentTimeMillis()}.mp4")
             val durationMs = endMs - startMs
 
-            val success = app.kreate.android.screens.player.share.encodeLyricsVideo(
-                cardBitmap = cardBitmap,
-                audioFile = audioFile,
-                outputFile = videoFile,
-                durationMs = durationMs
-            )
+            val success = if (animated) {
+                // Build per-line timestamps for the selected lyrics
+                val selectedTimestamps = selectedIndices.map { idx ->
+                    val tsIdx = (idx + 1).coerceIn(0, lyricsWithTimestamps.lastIndex)
+                    lyricsWithTimestamps[tsIdx].first
+                }
+
+                // Animated: karaoke-style highlighting at 15fps
+                val frameRenderer = app.kreate.android.screens.player.share.LyricsFrameRenderer(
+                    context = context,
+                    lyrics = selectedLyrics,
+                    lyricsTimestamps = selectedTimestamps,
+                    songTitle = songTitle,
+                    artistName = artistName,
+                    startMs = startMs,
+                    albumArt = albumArt
+                )
+
+                val result = app.kreate.android.screens.player.share.encodeLyricsVideo(
+                    frameRenderer = frameRenderer,
+                    audioFile = audioFile,
+                    outputFile = videoFile,
+                    durationMs = durationMs
+                )
+                frameRenderer.release()
+                result
+            } else {
+                // Static: single card image as video
+                val cardBitmap = createLyricsCardBitmap(
+                    context = context,
+                    lyrics = selectedLyrics,
+                    songTitle = songTitle,
+                    artistName = artistName,
+                    thumbnailUrl = thumbnailUrl
+                )
+                app.kreate.android.screens.player.share.encodeLyricsVideo(
+                    cardBitmap = cardBitmap,
+                    audioFile = audioFile,
+                    outputFile = videoFile,
+                    durationMs = durationMs
+                )
+            }
+
+            albumArt?.recycle()
 
             // Clean up audio temp file
             audioFile.delete()

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/AudioSegmentExtractor.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/AudioSegmentExtractor.kt
@@ -1,0 +1,388 @@
+package app.kreate.android.screens.player.share
+
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheSpan
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+
+private val logger = Logger.withTag("AudioSegmentExtractor")
+
+private const val AAC_MIME = MediaFormat.MIMETYPE_AUDIO_AAC
+private const val AAC_BITRATE = 128_000 // 128 kbps
+private const val TIMEOUT_US = 10_000L
+
+/**
+ * Extracts an audio segment between two timestamps from the Media3 cache.
+ *
+ * Steps:
+ * 1. Assembles the full cached audio into a temporary file
+ * 2. If the audio is Opus (or another format unsupported by MP4 muxer),
+ *    transcodes it to AAC while trimming to the desired range
+ * 3. Returns the trimmed AAC audio file
+ */
+suspend fun extractAudioSegment(
+    context: Context,
+    songId: String,
+    cache: Cache,
+    downloadCache: Cache,
+    startMs: Long,
+    endMs: Long
+): File? = withContext(Dispatchers.IO) {
+    try {
+        // Step 1: Assemble cached spans into a full audio file
+        val fullAudioFile = assembleCachedAudio(context, songId, cache, downloadCache)
+            ?: return@withContext null
+
+        // Step 2: Extract and transcode to AAC
+        val outputFile = File(context.cacheDir, "shared_lyrics/audio_segment_${System.currentTimeMillis()}.m4a")
+        outputFile.parentFile?.mkdirs()
+
+        val success = transcodeAudioSegment(fullAudioFile, outputFile, startMs, endMs)
+
+        // Clean up full audio temp file
+        fullAudioFile.delete()
+
+        if (success) outputFile else null
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to extract audio segment" }
+        null
+    }
+}
+
+/**
+ * Assembles the full audio from cache spans into a temporary file.
+ */
+private fun assembleCachedAudio(
+    context: Context,
+    songId: String,
+    cache: Cache,
+    downloadCache: Cache
+): File? {
+    // Check download cache first (fully downloaded songs), then regular cache
+    val spans: Set<CacheSpan> = downloadCache.getCachedSpans(songId).ifEmpty {
+        cache.getCachedSpans(songId)
+    }
+
+    if (spans.isEmpty()) {
+        logger.w { "No cached audio found for song: $songId" }
+        return null
+    }
+
+    val tempFile = File(context.cacheDir, "shared_lyrics/temp_full_audio_${System.currentTimeMillis()}")
+    tempFile.parentFile?.mkdirs()
+
+    FileOutputStream(tempFile).use { outputStream ->
+        spans.sortedBy { it.position }
+            .mapNotNull { it.file }
+            .forEach { spanFile ->
+                outputStream.write(spanFile.readBytes())
+            }
+    }
+
+    return tempFile
+}
+
+/**
+ * Decodes audio from the input file (any format), trims to the given range,
+ * and re-encodes as AAC into an M4A container.
+ */
+private fun transcodeAudioSegment(
+    inputFile: File,
+    outputFile: File,
+    startMs: Long,
+    endMs: Long
+): Boolean {
+    val extractor = MediaExtractor()
+
+    try {
+        extractor.setDataSource(inputFile.absolutePath)
+
+        // Find the audio track
+        val audioTrackIndex = (0 until extractor.trackCount).firstOrNull { i ->
+            extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+        } ?: run {
+            logger.e { "No audio track found in cached file" }
+            return false
+        }
+
+        extractor.selectTrack(audioTrackIndex)
+        val inputFormat = extractor.getTrackFormat(audioTrackIndex)
+        val inputMime = inputFormat.getString(MediaFormat.KEY_MIME) ?: "audio/unknown"
+        val sampleRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channelCount = inputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+
+        logger.i { "Input audio: mime=$inputMime, sampleRate=$sampleRate, channels=$channelCount" }
+
+        // Check if we can directly mux (AAC can be directly muxed into MP4)
+        if (inputMime == AAC_MIME) {
+            return trimAudioDirect(extractor, inputFormat, outputFile, startMs, endMs)
+        }
+
+        // Otherwise, transcode: Decode input → Encode to AAC
+        return transcodeToAac(extractor, inputFormat, outputFile, sampleRate, channelCount, startMs, endMs)
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to transcode audio segment" }
+        return false
+    } finally {
+        extractor.release()
+    }
+}
+
+/**
+ * Direct trim for formats already supported by MP4 muxer (e.g., AAC).
+ */
+private fun trimAudioDirect(
+    extractor: MediaExtractor,
+    inputFormat: MediaFormat,
+    outputFile: File,
+    startMs: Long,
+    endMs: Long
+): Boolean {
+    val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+    val outputTrackIndex = muxer.addTrack(inputFormat)
+    muxer.start()
+
+    val startUs = startMs * 1000L
+    val endUs = endMs * 1000L
+    extractor.seekTo(startUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+
+    val buffer = ByteBuffer.allocate(1024 * 1024)
+    val bufferInfo = MediaCodec.BufferInfo()
+
+    while (true) {
+        val sampleSize = extractor.readSampleData(buffer, 0)
+        if (sampleSize < 0) break
+
+        val sampleTime = extractor.sampleTime
+        if (sampleTime > endUs) break
+
+        if (sampleTime >= startUs) {
+            bufferInfo.offset = 0
+            bufferInfo.size = sampleSize
+            bufferInfo.presentationTimeUs = sampleTime - startUs
+            bufferInfo.flags = extractor.sampleFlags
+            muxer.writeSampleData(outputTrackIndex, buffer, bufferInfo)
+        }
+
+        extractor.advance()
+    }
+
+    muxer.stop()
+    muxer.release()
+    return true
+}
+
+/**
+ * Full transcode path: Decode any audio format → PCM → Encode to AAC → Mux into M4A.
+ */
+private fun transcodeToAac(
+    extractor: MediaExtractor,
+    inputFormat: MediaFormat,
+    outputFile: File,
+    sampleRate: Int,
+    channelCount: Int,
+    startMs: Long,
+    endMs: Long
+): Boolean {
+    val inputMime = inputFormat.getString(MediaFormat.KEY_MIME) ?: return false
+
+    // Set up decoder
+    val decoder = MediaCodec.createDecoderByType(inputMime)
+    decoder.configure(inputFormat, null, null, 0)
+    decoder.start()
+
+    // Set up AAC encoder
+    val encoderFormat = MediaFormat.createAudioFormat(AAC_MIME, sampleRate, channelCount).apply {
+        setInteger(MediaFormat.KEY_BIT_RATE, AAC_BITRATE)
+        setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+        setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 16384)
+    }
+    val encoder = MediaCodec.createEncoderByType(AAC_MIME)
+    encoder.configure(encoderFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+    encoder.start()
+
+    // Set up muxer (will be started once we get the encoder's output format)
+    val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+    var muxerTrackIndex = -1
+    var muxerStarted = false
+
+    val startUs = startMs * 1000L
+    val endUs = endMs * 1000L
+
+    // Seek to start
+    extractor.seekTo(startUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+
+    var inputDone = false
+    var decoderDone = false
+    val bufferInfo = MediaCodec.BufferInfo()
+
+    try {
+        while (!decoderDone) {
+            // Feed input to decoder
+            if (!inputDone) {
+                val inputBufferIndex = decoder.dequeueInputBuffer(TIMEOUT_US)
+                if (inputBufferIndex >= 0) {
+                    val inputBuffer = decoder.getInputBuffer(inputBufferIndex)!!
+                    val sampleSize = extractor.readSampleData(inputBuffer, 0)
+
+                    if (sampleSize < 0 || extractor.sampleTime > endUs) {
+                        decoder.queueInputBuffer(inputBufferIndex, 0, 0, 0,
+                            MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                        inputDone = true
+                    } else {
+                        val presentationTime = extractor.sampleTime
+                        decoder.queueInputBuffer(inputBufferIndex, 0, sampleSize, presentationTime, 0)
+                        extractor.advance()
+                    }
+                }
+            }
+
+            // Get decoded PCM from decoder and feed to encoder
+            val decoderOutputIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+            if (decoderOutputIndex >= 0) {
+                val isEos = bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
+
+                if (bufferInfo.size > 0 && bufferInfo.presentationTimeUs >= startUs) {
+                    val decodedBuffer = decoder.getOutputBuffer(decoderOutputIndex)!!
+                    // Feed PCM data to encoder
+                    feedEncoder(encoder, decodedBuffer, bufferInfo.size,
+                        bufferInfo.presentationTimeUs - startUs, isEos)
+                }
+
+                decoder.releaseOutputBuffer(decoderOutputIndex, false)
+
+                if (isEos) {
+                    // Signal EOS to encoder
+                    signalEncoderEos(encoder)
+                    decoderDone = true
+                }
+            }
+
+            // Drain encoder output to muxer
+            drainEncoderToMuxer(encoder, muxer, muxerTrackIndex, muxerStarted).let { (track, started) ->
+                muxerTrackIndex = track
+                muxerStarted = started
+            }
+        }
+
+        // Final drain of encoder
+        var draining = true
+        while (draining) {
+            val result = drainEncoderToMuxer(encoder, muxer, muxerTrackIndex, muxerStarted)
+            muxerTrackIndex = result.first
+            muxerStarted = result.second
+            // Check if encoder is done
+            val outIdx = encoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+            if (outIdx >= 0) {
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                    draining = false
+                }
+                encoder.releaseOutputBuffer(outIdx, false)
+            } else if (outIdx == MediaCodec.INFO_TRY_AGAIN_LATER) {
+                draining = false
+            }
+        }
+
+        if (muxerStarted) {
+            muxer.stop()
+        }
+        muxer.release()
+        encoder.stop()
+        encoder.release()
+        decoder.stop()
+        decoder.release()
+
+        return muxerStarted // Only success if we actually wrote some data
+    } catch (e: Exception) {
+        logger.e(e) { "Transcode error" }
+        try { muxer.release() } catch (_: Exception) {}
+        try { encoder.release() } catch (_: Exception) {}
+        try { decoder.release() } catch (_: Exception) {}
+        return false
+    }
+}
+
+private fun feedEncoder(
+    encoder: MediaCodec,
+    pcmData: ByteBuffer,
+    size: Int,
+    presentationTimeUs: Long,
+    isEos: Boolean
+) {
+    val inputIndex = encoder.dequeueInputBuffer(TIMEOUT_US)
+    if (inputIndex >= 0) {
+        val encoderInput = encoder.getInputBuffer(inputIndex)!!
+        encoderInput.clear()
+        val copySize = minOf(size, encoderInput.remaining())
+        val oldLimit = pcmData.limit()
+        pcmData.limit(pcmData.position() + copySize)
+        encoderInput.put(pcmData)
+        pcmData.limit(oldLimit)
+
+        encoder.queueInputBuffer(inputIndex, 0, copySize, presentationTimeUs,
+            if (isEos) MediaCodec.BUFFER_FLAG_END_OF_STREAM else 0)
+    }
+}
+
+private fun signalEncoderEos(encoder: MediaCodec) {
+    val inputIndex = encoder.dequeueInputBuffer(TIMEOUT_US)
+    if (inputIndex >= 0) {
+        encoder.queueInputBuffer(inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+    }
+}
+
+/**
+ * Drains available encoder output buffers into the muxer.
+ * Returns updated (muxerTrackIndex, muxerStarted) pair.
+ */
+private fun drainEncoderToMuxer(
+    encoder: MediaCodec,
+    muxer: MediaMuxer,
+    currentTrackIndex: Int,
+    currentMuxerStarted: Boolean
+): Pair<Int, Boolean> {
+    var trackIndex = currentTrackIndex
+    var muxerStarted = currentMuxerStarted
+    val bufferInfo = MediaCodec.BufferInfo()
+
+    while (true) {
+        val outputIndex = encoder.dequeueOutputBuffer(bufferInfo, 0) // non-blocking
+        when {
+            outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                trackIndex = muxer.addTrack(encoder.outputFormat)
+                muxer.start()
+                muxerStarted = true
+            }
+            outputIndex >= 0 -> {
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
+                    encoder.releaseOutputBuffer(outputIndex, false)
+                    continue
+                }
+                if (bufferInfo.size > 0 && muxerStarted) {
+                    val encodedData = encoder.getOutputBuffer(outputIndex)!!
+                    encodedData.position(bufferInfo.offset)
+                    encodedData.limit(bufferInfo.offset + bufferInfo.size)
+                    muxer.writeSampleData(trackIndex, encodedData, bufferInfo)
+                }
+                encoder.releaseOutputBuffer(outputIndex, false)
+
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                    return trackIndex to muxerStarted
+                }
+            }
+            else -> break // No more output available right now
+        }
+    }
+
+    return trackIndex to muxerStarted
+}

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsFrameRenderer.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsFrameRenderer.kt
@@ -1,0 +1,350 @@
+package app.kreate.android.screens.player.share
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.Typeface
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import app.kreate.android.coil3.ImageFactory
+import app.kreate.android.utils.blur
+import co.touchlab.kermit.Logger
+
+private val logger = Logger.withTag("LyricsFrameRenderer")
+
+/**
+ * Renders animated lyrics card frames for video encoding.
+ *
+ * Each frame highlights the currently active lyric line (karaoke-style)
+ * while dimming the others. Call [renderFrame] with the current timestamp
+ * to get a bitmap for that point in time.
+ *
+ * The renderer pre-computes the static elements (background, app icon, song info)
+ * and only redraws the lyrics text per frame for efficiency.
+ */
+class LyricsFrameRenderer(
+    private val context: Context,
+    private val lyrics: List<String>,
+    private val lyricsTimestamps: List<Long>,
+    private val songTitle: String,
+    private val artistName: String,
+    private val startMs: Long,
+    private val albumArt: Bitmap?
+) {
+    private val cardWidth = 1080
+    private val padding = 80f
+    private val topBarHeight = 100f
+    private val bottomInfoHeight = 140f
+    private val bottomPadding = 80f
+
+    // Pre-computed values
+    private val cardHeight: Int
+    private val backgroundBitmap: Bitmap
+    private val lyricsStartY: Float
+    private val textWidth: Int
+
+    init {
+        // Measure lyrics to determine card height (use all lines visible)
+        textWidth = (cardWidth - padding * 2).toInt()
+        val measurePaint = createLyricsPaint(isActive = true)
+        val fullText = lyrics.joinToString("\n")
+        val measureLayout = StaticLayout.Builder
+            .obtain(fullText, 0, fullText.length, measurePaint, textWidth)
+            .setAlignment(Layout.Alignment.ALIGN_CENTER)
+            .setLineSpacing(28f, 1.4f)
+            .setIncludePad(true)
+            .build()
+        val lyricsHeight = measureLayout.height.toFloat()
+
+        cardHeight = (padding + topBarHeight + 60f + lyricsHeight + 80f
+                + bottomInfoHeight + bottomPadding).toInt()
+            .coerceIn(800, 1920)
+
+        lyricsStartY = padding + topBarHeight + 60f
+
+        // Pre-render the static background (blurred art + gradient + app icon + song info)
+        backgroundBitmap = renderStaticBackground()
+    }
+
+    val width: Int get() = cardWidth
+    val height: Int get() = cardHeight
+
+    /**
+     * Renders a single frame at the given time position.
+     *
+     * @param currentTimeMs Time in milliseconds relative to the start of the video (0-based)
+     * @return Bitmap of the rendered frame
+     */
+    fun renderFrame(currentTimeMs: Long): Bitmap {
+        val bitmap = Bitmap.createBitmap(cardWidth, cardHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        // Draw pre-rendered background
+        canvas.drawBitmap(backgroundBitmap, 0f, 0f, null)
+
+        // Determine which line is active at this time
+        val absoluteTime = startMs + currentTimeMs
+        val activeLineIndex = findActiveLineIndex(absoluteTime)
+
+        // Draw lyrics with active line highlighted
+        drawAnimatedLyrics(canvas, activeLineIndex)
+
+        return bitmap
+    }
+
+    /**
+     * Finds which lyric line index is active at the given absolute timestamp.
+     */
+    private fun findActiveLineIndex(absoluteTimeMs: Long): Int {
+        var activeIndex = 0
+        for (i in lyricsTimestamps.indices) {
+            if (lyricsTimestamps[i] <= absoluteTimeMs) {
+                activeIndex = i
+            } else {
+                break
+            }
+        }
+        return activeIndex
+    }
+
+    /**
+     * Draws lyrics with the active line highlighted and others dimmed.
+     */
+    private fun drawAnimatedLyrics(canvas: Canvas, activeLineIndex: Int) {
+        var currentY = lyricsStartY
+
+        for (i in lyrics.indices) {
+            val isActive = i == activeLineIndex
+            val paint = createLyricsPaint(isActive)
+
+            val lineLayout = StaticLayout.Builder
+                .obtain(lyrics[i], 0, lyrics[i].length, paint, textWidth)
+                .setAlignment(Layout.Alignment.ALIGN_CENTER)
+                .setLineSpacing(8f, 1.2f)
+                .setIncludePad(true)
+                .build()
+
+            canvas.save()
+            canvas.translate(cardWidth / 2f, currentY)
+            lineLayout.draw(canvas)
+            canvas.restore()
+
+            currentY += lineLayout.height + 28f  // line height + spacing
+        }
+    }
+
+    /**
+     * Creates a TextPaint for a lyric line based on whether it's the active line.
+     */
+    private fun createLyricsPaint(isActive: Boolean): TextPaint {
+        return TextPaint().apply {
+            color = if (isActive) Color.WHITE else Color.argb(90, 255, 255, 255)
+            textSize = if (isActive) 62f else 54f
+            isAntiAlias = true
+            typeface = if (isActive) {
+                Typeface.create("sans-serif-medium", Typeface.BOLD)
+            } else {
+                Typeface.create("sans-serif", Typeface.NORMAL)
+            }
+            textAlign = Paint.Align.CENTER
+            letterSpacing = 0.01f
+        }
+    }
+
+    /**
+     * Pre-renders all static elements into a background bitmap:
+     * blurred background, gradient, app icon, song info row.
+     */
+    private fun renderStaticBackground(): Bitmap {
+        val bitmap = Bitmap.createBitmap(cardWidth, cardHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        // Background
+        if (albumArt != null) {
+            drawBlurredBackground(canvas, albumArt)
+        } else {
+            drawFallbackBackground(canvas)
+        }
+
+        // Gradient overlay
+        drawGradientOverlay(canvas)
+
+        // App icon (top-left)
+        drawAppIcon(canvas)
+
+        // Song info row (bottom)
+        drawSongInfoRow(canvas)
+
+        return bitmap
+    }
+
+    private fun drawBlurredBackground(canvas: Canvas, art: Bitmap) {
+        val srcRatio = art.width.toFloat() / art.height.toFloat()
+        val dstRatio = cardWidth.toFloat() / cardHeight.toFloat()
+
+        val scaled = if (srcRatio > dstRatio) {
+            val scaledWidth = (cardHeight * srcRatio).toInt()
+            Bitmap.createScaledBitmap(art, scaledWidth, cardHeight, true)
+        } else {
+            val scaledHeight = (cardWidth / srcRatio).toInt()
+            Bitmap.createScaledBitmap(art, cardWidth, scaledHeight, true)
+        }
+
+        val cropX = ((scaled.width - cardWidth) / 2).coerceAtLeast(0)
+        val cropY = ((scaled.height - cardHeight) / 2).coerceAtLeast(0)
+        val cropped = Bitmap.createBitmap(
+            scaled, cropX, cropY,
+            cardWidth.coerceAtMost(scaled.width - cropX),
+            cardHeight.coerceAtMost(scaled.height - cropY)
+        )
+
+        // We can't call suspend blur() here, so use a simple darkening instead
+        // The bitmap is already loaded and ready
+        val darkened = Bitmap.createScaledBitmap(cropped, cardWidth / 4, cardHeight / 4, true)
+        val fullSize = Bitmap.createScaledBitmap(darkened, cardWidth, cardHeight, true)
+        canvas.drawBitmap(fullSize, 0f, 0f, null)
+        darkened.recycle()
+        fullSize.recycle()
+        if (cropped !== scaled) cropped.recycle()
+        scaled.recycle()
+    }
+
+    private fun drawFallbackBackground(canvas: Canvas) {
+        val bgPaint = Paint().apply {
+            shader = LinearGradient(
+                0f, 0f, cardWidth.toFloat(), cardHeight.toFloat(),
+                Color.parseColor("#0f0c29"),
+                Color.parseColor("#302b63"),
+                Shader.TileMode.CLAMP
+            )
+        }
+        canvas.drawRect(0f, 0f, cardWidth.toFloat(), cardHeight.toFloat(), bgPaint)
+    }
+
+    private fun drawGradientOverlay(canvas: Canvas) {
+        val overlayPaint = Paint().apply {
+            shader = LinearGradient(
+                0f, 0f, 0f, cardHeight.toFloat(),
+                intArrayOf(
+                    Color.argb(200, 0, 0, 0),
+                    Color.argb(120, 0, 0, 0),
+                    Color.argb(100, 0, 0, 0),
+                    Color.argb(140, 0, 0, 0),
+                    Color.argb(230, 0, 0, 0)
+                ),
+                floatArrayOf(0f, 0.25f, 0.45f, 0.7f, 1f),
+                Shader.TileMode.CLAMP
+            )
+        }
+        canvas.drawRect(0f, 0f, cardWidth.toFloat(), cardHeight.toFloat(), overlayPaint)
+    }
+
+    private fun drawAppIcon(canvas: Canvas) {
+        val iconSize = 72f
+        val iconTop = padding
+        val iconLeft = padding
+
+        try {
+            val iconDrawable = context.packageManager.getApplicationIcon(context.packageName)
+            val iconBitmap = Bitmap.createBitmap(iconSize.toInt(), iconSize.toInt(), Bitmap.Config.ARGB_8888)
+            val iconCanvas = Canvas(iconBitmap)
+            iconDrawable.setBounds(0, 0, iconSize.toInt(), iconSize.toInt())
+            iconDrawable.draw(iconCanvas)
+
+            val path = android.graphics.Path().apply {
+                addCircle(iconLeft + iconSize / 2f, iconTop + iconSize / 2f, iconSize / 2f,
+                    android.graphics.Path.Direction.CW)
+            }
+            canvas.save()
+            canvas.clipPath(path)
+            canvas.drawBitmap(iconBitmap, iconLeft, iconTop, null)
+            canvas.restore()
+            iconBitmap.recycle()
+        } catch (_: Exception) {
+            val circlePaint = Paint().apply {
+                color = Color.argb(80, 255, 255, 255)
+                isAntiAlias = true
+            }
+            canvas.drawCircle(iconLeft + iconSize / 2f, iconTop + iconSize / 2f, iconSize / 2f, circlePaint)
+        }
+    }
+
+    private fun drawSongInfoRow(canvas: Canvas) {
+        val thumbSize = 96f
+        val cornerRadius = 16f
+        val rowY = cardHeight - bottomPadding - thumbSize
+        val thumbLeft = padding
+        val textLeft = thumbLeft + thumbSize + 24f
+
+        // Album art thumbnail
+        if (albumArt != null) {
+            val scaledArt = Bitmap.createScaledBitmap(albumArt, thumbSize.toInt(), thumbSize.toInt(), true)
+            val path = android.graphics.Path().apply {
+                addRoundRect(
+                    RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+                    cornerRadius, cornerRadius, android.graphics.Path.Direction.CW)
+            }
+            canvas.save()
+            canvas.clipPath(path)
+            canvas.drawBitmap(scaledArt, thumbLeft, rowY, null)
+            canvas.restore()
+            scaledArt.recycle()
+
+            val borderPaint = Paint().apply {
+                style = Paint.Style.STROKE
+                color = Color.argb(50, 255, 255, 255)
+                strokeWidth = 2f
+                isAntiAlias = true
+            }
+            canvas.drawRoundRect(
+                RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+                cornerRadius, cornerRadius, borderPaint)
+        } else {
+            val placeholderPaint = Paint().apply { color = Color.argb(40, 255, 255, 255); isAntiAlias = true }
+            canvas.drawRoundRect(
+                RectF(thumbLeft, rowY, thumbLeft + thumbSize, rowY + thumbSize),
+                cornerRadius, cornerRadius, placeholderPaint)
+        }
+
+        // Song title
+        val titlePaint = TextPaint().apply {
+            color = Color.WHITE
+            textSize = 38f
+            isAntiAlias = true
+            typeface = Typeface.create("sans-serif-medium", Typeface.BOLD)
+            textAlign = Paint.Align.LEFT
+        }
+        val maxTextWidth = cardWidth - textLeft - padding
+        val displayTitle = if (titlePaint.measureText(songTitle) > maxTextWidth) {
+            var t = songTitle
+            while (titlePaint.measureText("$t…") > maxTextWidth && t.isNotEmpty()) t = t.dropLast(1)
+            "$t…"
+        } else songTitle
+
+        val titleY = rowY + thumbSize / 2f - 8f
+        canvas.drawText(displayTitle, textLeft, titleY, titlePaint)
+
+        // Artist name
+        val artistPaint = TextPaint().apply {
+            color = Color.argb(160, 255, 255, 255)
+            textSize = 32f
+            isAntiAlias = true
+            typeface = Typeface.create("sans-serif", Typeface.NORMAL)
+            textAlign = Paint.Align.LEFT
+        }
+        canvas.drawText(artistName, textLeft, titleY + 42f, artistPaint)
+    }
+
+    /**
+     * Recycles the pre-rendered background bitmap. Call when done encoding.
+     */
+    fun release() {
+        backgroundBitmap.recycle()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsVideoEncoder.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsVideoEncoder.kt
@@ -1,0 +1,424 @@
+package app.kreate.android.screens.player.share
+
+import android.graphics.Bitmap
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLSurface
+import android.opengl.GLES20
+import android.view.Surface
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+private val logger = Logger.withTag("LyricsVideoEncoder")
+
+private const val VIDEO_MIME_TYPE = MediaFormat.MIMETYPE_VIDEO_AVC
+private const val FRAME_RATE = 1  // 1 fps — static image
+private const val I_FRAME_INTERVAL = 1
+private const val VIDEO_BITRATE = 2_000_000  // 2 Mbps
+private const val CODEC_TIMEOUT_US = 10_000L
+
+/**
+ * Encodes a static lyrics card bitmap + audio segment into an MP4 video file.
+ *
+ * Strategy: Encode video frames first into a temp file, then mux video + audio
+ * together in a second pass. This avoids the "muxer already started" issue
+ * since MediaMuxer requires all tracks added before start().
+ */
+suspend fun encodeLyricsVideo(
+    cardBitmap: Bitmap,
+    audioFile: File,
+    outputFile: File,
+    durationMs: Long
+): Boolean = withContext(Dispatchers.IO) {
+    try {
+        outputFile.parentFile?.mkdirs()
+
+        val width = cardBitmap.width
+        val height = cardBitmap.height
+
+        // Ensure dimensions are even (required by H.264)
+        val encoderWidth = if (width % 2 == 0) width else width + 1
+        val encoderHeight = if (height % 2 == 0) height else height + 1
+
+        // Step 1: Encode video to a temp file
+        val tempVideoFile = File(outputFile.parent, "temp_video_${System.currentTimeMillis()}.mp4")
+        val videoSuccess = encodeVideoOnly(cardBitmap, tempVideoFile, encoderWidth, encoderHeight, durationMs)
+        if (!videoSuccess) {
+            tempVideoFile.delete()
+            return@withContext false
+        }
+
+        // Step 2: Mux video + audio into the final output
+        val muxSuccess = muxVideoAndAudio(tempVideoFile, audioFile, outputFile)
+        tempVideoFile.delete()
+
+        if (muxSuccess) {
+            logger.i { "Video encoded successfully: ${outputFile.absolutePath}" }
+        }
+        muxSuccess
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to encode lyrics video" }
+        outputFile.delete()
+        false
+    }
+}
+
+/**
+ * Encodes the bitmap as a video-only MP4 file.
+ */
+private fun encodeVideoOnly(
+    bitmap: Bitmap,
+    outputFile: File,
+    width: Int,
+    height: Int,
+    durationMs: Long
+): Boolean {
+    val format = MediaFormat.createVideoFormat(VIDEO_MIME_TYPE, width, height).apply {
+        setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+        setInteger(MediaFormat.KEY_BIT_RATE, VIDEO_BITRATE)
+        setInteger(MediaFormat.KEY_FRAME_RATE, FRAME_RATE)
+        setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, I_FRAME_INTERVAL)
+    }
+
+    val codec = MediaCodec.createEncoderByType(VIDEO_MIME_TYPE)
+    codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+
+    val inputSurface = codec.createInputSurface()
+    codec.start()
+
+    val eglHelper = EglHelper(inputSurface)
+    eglHelper.makeCurrent()
+
+    val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+    var videoTrackIndex = -1
+    var muxerStarted = false
+    val bufferInfo = MediaCodec.BufferInfo()
+
+    val durationUs = durationMs * 1000L
+    val frameIntervalUs = 1_000_000L / FRAME_RATE
+    val totalFrames = ((durationUs + frameIntervalUs - 1) / frameIntervalUs).toInt().coerceAtLeast(1)
+
+    try {
+        // Render frames
+        for (frameIndex in 0 until totalFrames) {
+            val presentationTimeUs = frameIndex * frameIntervalUs
+
+            renderBitmapToSurface(bitmap, width, height)
+            eglHelper.setPresentationTime(presentationTimeUs * 1000) // convert to nanoseconds
+            eglHelper.swapBuffers()
+
+            // Drain encoder
+            drainEncoder(codec, muxer, bufferInfo, videoTrackIndex, muxerStarted, false).let {
+                videoTrackIndex = it.first
+                muxerStarted = it.second
+            }
+        }
+
+        // Signal end of stream
+        codec.signalEndOfInputStream()
+        drainEncoder(codec, muxer, bufferInfo, videoTrackIndex, muxerStarted, true)
+
+        muxer.stop()
+        muxer.release()
+        eglHelper.release()
+        codec.stop()
+        codec.release()
+
+        return true
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to encode video frames" }
+        try { muxer.release() } catch (_: Exception) {}
+        try { eglHelper.release() } catch (_: Exception) {}
+        try { codec.release() } catch (_: Exception) {}
+        return false
+    }
+}
+
+/**
+ * Muxes a video-only MP4 and an audio file together into a final MP4.
+ */
+private fun muxVideoAndAudio(
+    videoFile: File,
+    audioFile: File,
+    outputFile: File
+): Boolean {
+    val videoExtractor = MediaExtractor()
+    val audioExtractor = MediaExtractor()
+
+    try {
+        videoExtractor.setDataSource(videoFile.absolutePath)
+        audioExtractor.setDataSource(audioFile.absolutePath)
+
+        val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+
+        // Find and add video track
+        val videoTrackSrcIdx = (0 until videoExtractor.trackCount).first { i ->
+            videoExtractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("video/") == true
+        }
+        videoExtractor.selectTrack(videoTrackSrcIdx)
+        val videoFormat = videoExtractor.getTrackFormat(videoTrackSrcIdx)
+        val videoTrackDstIdx = muxer.addTrack(videoFormat)
+
+        // Find and add audio track
+        val audioTrackSrcIdx = (0 until audioExtractor.trackCount).first { i ->
+            audioExtractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+        }
+        audioExtractor.selectTrack(audioTrackSrcIdx)
+        val audioFormat = audioExtractor.getTrackFormat(audioTrackSrcIdx)
+        val audioTrackDstIdx = muxer.addTrack(audioFormat)
+
+        // Start muxer after all tracks are added
+        muxer.start()
+
+        val buffer = ByteBuffer.allocate(1024 * 1024)
+        val bufferInfo = MediaCodec.BufferInfo()
+
+        // Write video samples
+        while (true) {
+            val sampleSize = videoExtractor.readSampleData(buffer, 0)
+            if (sampleSize < 0) break
+            bufferInfo.offset = 0
+            bufferInfo.size = sampleSize
+            bufferInfo.presentationTimeUs = videoExtractor.sampleTime
+            bufferInfo.flags = videoExtractor.sampleFlags
+            muxer.writeSampleData(videoTrackDstIdx, buffer, bufferInfo)
+            videoExtractor.advance()
+        }
+
+        // Write audio samples
+        while (true) {
+            val sampleSize = audioExtractor.readSampleData(buffer, 0)
+            if (sampleSize < 0) break
+            bufferInfo.offset = 0
+            bufferInfo.size = sampleSize
+            bufferInfo.presentationTimeUs = audioExtractor.sampleTime
+            bufferInfo.flags = audioExtractor.sampleFlags
+            muxer.writeSampleData(audioTrackDstIdx, buffer, bufferInfo)
+            audioExtractor.advance()
+        }
+
+        muxer.stop()
+        muxer.release()
+        return true
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to mux video and audio" }
+        return false
+    } finally {
+        videoExtractor.release()
+        audioExtractor.release()
+    }
+}
+
+/**
+ * Drains encoded data from the codec and writes to the muxer.
+ * Returns updated (trackIndex, muxerStarted) pair.
+ */
+private fun drainEncoder(
+    codec: MediaCodec,
+    muxer: MediaMuxer,
+    bufferInfo: MediaCodec.BufferInfo,
+    currentTrackIndex: Int,
+    currentMuxerStarted: Boolean,
+    endOfStream: Boolean
+): Pair<Int, Boolean> {
+    var trackIndex = currentTrackIndex
+    var muxerStarted = currentMuxerStarted
+    val timeoutUs = if (endOfStream) CODEC_TIMEOUT_US else 0L
+
+    while (true) {
+        val outputBufferIndex = codec.dequeueOutputBuffer(bufferInfo, timeoutUs)
+
+        when {
+            outputBufferIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                val newFormat = codec.outputFormat
+                trackIndex = muxer.addTrack(newFormat)
+                muxer.start()
+                muxerStarted = true
+            }
+            outputBufferIndex >= 0 -> {
+                val encodedData = codec.getOutputBuffer(outputBufferIndex) ?: run {
+                    codec.releaseOutputBuffer(outputBufferIndex, false)
+                    continue
+                }
+
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
+                    bufferInfo.size = 0
+                }
+
+                if (bufferInfo.size > 0 && muxerStarted) {
+                    encodedData.position(bufferInfo.offset)
+                    encodedData.limit(bufferInfo.offset + bufferInfo.size)
+                    muxer.writeSampleData(trackIndex, encodedData, bufferInfo)
+                }
+
+                codec.releaseOutputBuffer(outputBufferIndex, false)
+
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                    return trackIndex to muxerStarted
+                }
+            }
+            else -> {
+                if (!endOfStream) break
+                // If end of stream and no output yet, try again briefly
+                if (outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER && endOfStream) {
+                    break
+                }
+            }
+        }
+    }
+
+    return trackIndex to muxerStarted
+}
+
+/**
+ * Renders a bitmap to the current OpenGL surface using GLES20.
+ */
+private fun renderBitmapToSurface(bitmap: Bitmap, width: Int, height: Int) {
+    GLES20.glViewport(0, 0, width, height)
+    GLES20.glClearColor(0f, 0f, 0f, 1f)
+    GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+
+    val textures = IntArray(1)
+    GLES20.glGenTextures(1, textures, 0)
+    GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textures[0])
+    GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+    GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+
+    android.opengl.GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
+
+    val vertexShaderCode = """
+        attribute vec4 aPosition;
+        attribute vec2 aTexCoord;
+        varying vec2 vTexCoord;
+        void main() {
+            gl_Position = aPosition;
+            vTexCoord = aTexCoord;
+        }
+    """.trimIndent()
+
+    val fragmentShaderCode = """
+        precision mediump float;
+        varying vec2 vTexCoord;
+        uniform sampler2D uTexture;
+        void main() {
+            gl_FragColor = texture2D(uTexture, vTexCoord);
+        }
+    """.trimIndent()
+
+    val vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, vertexShaderCode)
+    val fragmentShader = loadShader(GLES20.GL_FRAGMENT_SHADER, fragmentShaderCode)
+
+    val program = GLES20.glCreateProgram()
+    GLES20.glAttachShader(program, vertexShader)
+    GLES20.glAttachShader(program, fragmentShader)
+    GLES20.glLinkProgram(program)
+    GLES20.glUseProgram(program)
+
+    val vertices = floatArrayOf(
+        -1f, -1f,  0f, 1f,
+         1f, -1f,  1f, 1f,
+        -1f,  1f,  0f, 0f,
+         1f,  1f,  1f, 0f
+    )
+    val vertexBuffer = ByteBuffer.allocateDirect(vertices.size * 4)
+        .order(ByteOrder.nativeOrder())
+        .asFloatBuffer()
+        .put(vertices)
+
+    val positionHandle = GLES20.glGetAttribLocation(program, "aPosition")
+    GLES20.glEnableVertexAttribArray(positionHandle)
+    (vertexBuffer as java.nio.Buffer).position(0)
+    GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false, 16, vertexBuffer)
+
+    val texCoordHandle = GLES20.glGetAttribLocation(program, "aTexCoord")
+    GLES20.glEnableVertexAttribArray(texCoordHandle)
+    (vertexBuffer as java.nio.Buffer).position(2)
+    GLES20.glVertexAttribPointer(texCoordHandle, 2, GLES20.GL_FLOAT, false, 16, vertexBuffer)
+
+    GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+
+    GLES20.glDeleteTextures(1, textures, 0)
+    GLES20.glDeleteProgram(program)
+    GLES20.glDeleteShader(vertexShader)
+    GLES20.glDeleteShader(fragmentShader)
+}
+
+private fun loadShader(type: Int, shaderCode: String): Int {
+    val shader = GLES20.glCreateShader(type)
+    GLES20.glShaderSource(shader, shaderCode)
+    GLES20.glCompileShader(shader)
+    return shader
+}
+
+/**
+ * EGL helper for rendering to a MediaCodec input surface.
+ */
+private class EglHelper(surface: Surface) {
+    private val eglDisplay: EGLDisplay
+    private val eglContext: EGLContext
+    private val eglSurface: EGLSurface
+
+    init {
+        eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+        val version = IntArray(2)
+        EGL14.eglInitialize(eglDisplay, version, 0, version, 1)
+
+        val configAttribs = intArrayOf(
+            EGL14.EGL_RED_SIZE, 8,
+            EGL14.EGL_GREEN_SIZE, 8,
+            EGL14.EGL_BLUE_SIZE, 8,
+            EGL14.EGL_ALPHA_SIZE, 8,
+            EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+            EGL14.EGL_SURFACE_TYPE, EGL14.EGL_WINDOW_BIT,
+            EGL14.EGL_NONE
+        )
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val numConfigs = IntArray(1)
+        EGL14.eglChooseConfig(eglDisplay, configAttribs, 0, configs, 0, 1, numConfigs, 0)
+
+        val contextAttribs = intArrayOf(
+            EGL14.EGL_CONTEXT_CLIENT_VERSION, 2,
+            EGL14.EGL_NONE
+        )
+        eglContext = EGL14.eglCreateContext(
+            eglDisplay, configs[0]!!, EGL14.EGL_NO_CONTEXT, contextAttribs, 0
+        )
+
+        val surfaceAttribs = intArrayOf(EGL14.EGL_NONE)
+        eglSurface = EGL14.eglCreateWindowSurface(
+            eglDisplay, configs[0]!!, surface, surfaceAttribs, 0
+        )
+    }
+
+    fun makeCurrent() {
+        EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)
+    }
+
+    fun swapBuffers() {
+        EGL14.eglSwapBuffers(eglDisplay, eglSurface)
+    }
+
+    fun setPresentationTime(nsecs: Long) {
+        android.opengl.EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, nsecs)
+    }
+
+    fun release() {
+        EGL14.eglMakeCurrent(
+            eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_CONTEXT
+        )
+        EGL14.eglDestroySurface(eglDisplay, eglSurface)
+        EGL14.eglDestroyContext(eglDisplay, eglContext)
+        EGL14.eglTerminate(eglDisplay)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsVideoEncoder.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/screens/player/share/LyricsVideoEncoder.kt
@@ -23,17 +23,63 @@ import java.nio.ByteOrder
 private val logger = Logger.withTag("LyricsVideoEncoder")
 
 private const val VIDEO_MIME_TYPE = MediaFormat.MIMETYPE_VIDEO_AVC
-private const val FRAME_RATE = 1  // 1 fps — static image
-private const val I_FRAME_INTERVAL = 1
-private const val VIDEO_BITRATE = 2_000_000  // 2 Mbps
+private const val FRAME_RATE = 15  // 15fps — smooth enough for text animation, keeps file size down
+private const val I_FRAME_INTERVAL = 2
+private const val VIDEO_BITRATE = 1_000_000  // 1 Mbps — sufficient for text over blurred image
 private const val CODEC_TIMEOUT_US = 10_000L
 
 /**
- * Encodes a static lyrics card bitmap + audio segment into an MP4 video file.
+ * Encodes an animated lyrics video with audio into an MP4.
+ *
+ * Uses [LyricsFrameRenderer] to generate per-frame bitmaps with the active
+ * lyric line highlighted (karaoke-style). Renders at 15fps.
  *
  * Strategy: Encode video frames first into a temp file, then mux video + audio
- * together in a second pass. This avoids the "muxer already started" issue
- * since MediaMuxer requires all tracks added before start().
+ * together in a second pass.
+ */
+suspend fun encodeLyricsVideo(
+    frameRenderer: LyricsFrameRenderer,
+    audioFile: File,
+    outputFile: File,
+    durationMs: Long
+): Boolean = withContext(Dispatchers.IO) {
+    try {
+        outputFile.parentFile?.mkdirs()
+
+        val width = frameRenderer.width
+        val height = frameRenderer.height
+
+        // Ensure dimensions are even (required by H.264)
+        val encoderWidth = if (width % 2 == 0) width else width + 1
+        val encoderHeight = if (height % 2 == 0) height else height + 1
+
+        // Step 1: Encode animated video frames to a temp file
+        val tempVideoFile = File(outputFile.parent, "temp_video_${System.currentTimeMillis()}.mp4")
+        val videoSuccess = encodeVideoFrames(
+            frameRenderer, tempVideoFile, encoderWidth, encoderHeight, durationMs
+        )
+        if (!videoSuccess) {
+            tempVideoFile.delete()
+            return@withContext false
+        }
+
+        // Step 2: Mux video + audio into the final output
+        val muxSuccess = muxVideoAndAudio(tempVideoFile, audioFile, outputFile)
+        tempVideoFile.delete()
+
+        if (muxSuccess) {
+            logger.i { "Animated lyrics video encoded: ${outputFile.absolutePath}" }
+        }
+        muxSuccess
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to encode lyrics video" }
+        outputFile.delete()
+        false
+    }
+}
+
+/**
+ * Overload that accepts a static bitmap (backwards compatible with non-animated usage).
  */
 suspend fun encodeLyricsVideo(
     cardBitmap: Bitmap,
@@ -46,25 +92,21 @@ suspend fun encodeLyricsVideo(
 
         val width = cardBitmap.width
         val height = cardBitmap.height
-
-        // Ensure dimensions are even (required by H.264)
         val encoderWidth = if (width % 2 == 0) width else width + 1
         val encoderHeight = if (height % 2 == 0) height else height + 1
 
-        // Step 1: Encode video to a temp file
         val tempVideoFile = File(outputFile.parent, "temp_video_${System.currentTimeMillis()}.mp4")
-        val videoSuccess = encodeVideoOnly(cardBitmap, tempVideoFile, encoderWidth, encoderHeight, durationMs)
+        val videoSuccess = encodeStaticVideo(cardBitmap, tempVideoFile, encoderWidth, encoderHeight, durationMs)
         if (!videoSuccess) {
             tempVideoFile.delete()
             return@withContext false
         }
 
-        // Step 2: Mux video + audio into the final output
         val muxSuccess = muxVideoAndAudio(tempVideoFile, audioFile, outputFile)
         tempVideoFile.delete()
 
         if (muxSuccess) {
-            logger.i { "Video encoded successfully: ${outputFile.absolutePath}" }
+            logger.i { "Static lyrics video encoded: ${outputFile.absolutePath}" }
         }
         muxSuccess
     } catch (e: Exception) {
@@ -75,10 +117,10 @@ suspend fun encodeLyricsVideo(
 }
 
 /**
- * Encodes the bitmap as a video-only MP4 file.
+ * Encodes animated frames from the renderer into a video-only MP4.
  */
-private fun encodeVideoOnly(
-    bitmap: Bitmap,
+private fun encodeVideoFrames(
+    frameRenderer: LyricsFrameRenderer,
     outputFile: File,
     width: Int,
     height: Int,
@@ -109,13 +151,21 @@ private fun encodeVideoOnly(
     val frameIntervalUs = 1_000_000L / FRAME_RATE
     val totalFrames = ((durationUs + frameIntervalUs - 1) / frameIntervalUs).toInt().coerceAtLeast(1)
 
+    logger.i { "Encoding $totalFrames frames at ${FRAME_RATE}fps for ${durationMs}ms" }
+
     try {
-        // Render frames
         for (frameIndex in 0 until totalFrames) {
             val presentationTimeUs = frameIndex * frameIntervalUs
+            val currentTimeMs = presentationTimeUs / 1000L
 
-            renderBitmapToSurface(bitmap, width, height)
-            eglHelper.setPresentationTime(presentationTimeUs * 1000) // convert to nanoseconds
+            // Render the frame with current active lyric highlighted
+            val frameBitmap = frameRenderer.renderFrame(currentTimeMs)
+
+            // Draw to encoder surface
+            renderBitmapToSurface(frameBitmap, width, height)
+            frameBitmap.recycle()
+
+            eglHelper.setPresentationTime(presentationTimeUs * 1000) // to nanoseconds
             eglHelper.swapBuffers()
 
             // Drain encoder
@@ -137,7 +187,75 @@ private fun encodeVideoOnly(
 
         return true
     } catch (e: Exception) {
-        logger.e(e) { "Failed to encode video frames" }
+        logger.e(e) { "Failed to encode animated video frames" }
+        try { muxer.release() } catch (_: Exception) {}
+        try { eglHelper.release() } catch (_: Exception) {}
+        try { codec.release() } catch (_: Exception) {}
+        return false
+    }
+}
+
+/**
+ * Encodes a static bitmap as video frames (1fps, for fallback/backwards compat).
+ */
+private fun encodeStaticVideo(
+    bitmap: Bitmap,
+    outputFile: File,
+    width: Int,
+    height: Int,
+    durationMs: Long
+): Boolean {
+    val staticFps = 1
+    val format = MediaFormat.createVideoFormat(VIDEO_MIME_TYPE, width, height).apply {
+        setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+        setInteger(MediaFormat.KEY_BIT_RATE, VIDEO_BITRATE)
+        setInteger(MediaFormat.KEY_FRAME_RATE, staticFps)
+        setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1)
+    }
+
+    val codec = MediaCodec.createEncoderByType(VIDEO_MIME_TYPE)
+    codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+
+    val inputSurface = codec.createInputSurface()
+    codec.start()
+
+    val eglHelper = EglHelper(inputSurface)
+    eglHelper.makeCurrent()
+
+    val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+    var videoTrackIndex = -1
+    var muxerStarted = false
+    val bufferInfo = MediaCodec.BufferInfo()
+
+    val durationUs = durationMs * 1000L
+    val frameIntervalUs = 1_000_000L / staticFps
+    val totalFrames = ((durationUs + frameIntervalUs - 1) / frameIntervalUs).toInt().coerceAtLeast(1)
+
+    try {
+        for (frameIndex in 0 until totalFrames) {
+            val presentationTimeUs = frameIndex * frameIntervalUs
+
+            renderBitmapToSurface(bitmap, width, height)
+            eglHelper.setPresentationTime(presentationTimeUs * 1000)
+            eglHelper.swapBuffers()
+
+            drainEncoder(codec, muxer, bufferInfo, videoTrackIndex, muxerStarted, false).let {
+                videoTrackIndex = it.first
+                muxerStarted = it.second
+            }
+        }
+
+        codec.signalEndOfInputStream()
+        drainEncoder(codec, muxer, bufferInfo, videoTrackIndex, muxerStarted, true)
+
+        muxer.stop()
+        muxer.release()
+        eglHelper.release()
+        codec.stop()
+        codec.release()
+        return true
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to encode static video" }
         try { muxer.release() } catch (_: Exception) {}
         try { eglHelper.release() } catch (_: Exception) {}
         try { codec.release() } catch (_: Exception) {}
@@ -222,7 +340,6 @@ private fun muxVideoAndAudio(
 
 /**
  * Drains encoded data from the codec and writes to the muxer.
- * Returns updated (trackIndex, muxerStarted) pair.
  */
 private fun drainEncoder(
     codec: MediaCodec,
@@ -270,10 +387,7 @@ private fun drainEncoder(
             }
             else -> {
                 if (!endOfStream) break
-                // If end of stream and no output yet, try again briefly
-                if (outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER && endOfStream) {
-                    break
-                }
+                if (outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER) break
             }
         }
     }
@@ -282,7 +396,7 @@ private fun drainEncoder(
 }
 
 /**
- * Renders a bitmap to the current OpenGL surface using GLES20.
+ * Renders a bitmap to the current OpenGL surface.
  */
 private fun renderBitmapToSurface(bitmap: Bitmap, width: Int, height: Int) {
     GLES20.glViewport(0, 0, width, height)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -2368,7 +2368,7 @@ fun Lyrics(
 
                                         MenuEntry(
                                             icon = R.drawable.share_social,
-                                            text = stringResource(R.string.lyrics_share_as_image),
+                                            text = stringResource(R.string.lyrics_share),
                                             onClick = {
                                                 menuState.hide()
                                                 isLyricsShareMode = true

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
@@ -210,6 +211,10 @@ fun Lyrics(
         val colorPaletteMode by Preferences.THEME_MODE
 
         var isEditing by remember(mediaId, isShowingSynchronizedLyrics) {
+            mutableStateOf(false)
+        }
+
+        var isLyricsShareMode by remember(mediaId) {
             mutableStateOf(false)
         }
 
@@ -816,10 +821,12 @@ fun Lyrics(
         Box(
             contentAlignment = Alignment.Center,
             modifier = modifier
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onDismiss() }
-                    )
+                .pointerInput(isLyricsShareMode) {
+                    if (!isLyricsShareMode) {
+                        detectTapGestures(
+                            onTap = { onDismiss() }
+                        )
+                    }
                 }
                 .fillMaxSize()
                 .background(if (!showlyricsthumbnail) Color.Transparent else Color.Black.copy(0.8f))
@@ -849,6 +856,31 @@ fun Lyrics(
 
             if (text?.isEmpty() == true && !checkedLyricsLrc && !checkedLyricsKugou && !checkedLyricsInnertube)
                 checkLyrics = !checkLyrics
+
+            // Lyrics Share Mode overlay
+            AnimatedVisibility(
+                visible = isLyricsShareMode && text?.isNotEmpty() == true,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(10f)
+                    .background(Color.Black.copy(0.95f))
+            ) {
+                val lyricsLines = remember(text, isShowingSynchronizedLyrics) {
+                    app.kreate.android.screens.player.parseLyricsToLines(text, isShowingSynchronizedLyrics)
+                }
+                val mediaMetadata = mediaMetadataProvider()
+                app.kreate.android.screens.player.LyricsSelectionMode(
+                    lyrics = lyricsLines,
+                    songTitle = cleanPrefix(mediaMetadata.title?.toString().orEmpty()),
+                    artistName = cleanPrefix(mediaMetadata.artist?.toString().orEmpty()),
+                    thumbnailUrl = mediaMetadata.artworkUri?.toString(),
+                    mediaId = mediaId,
+                    currentPosition = player.currentPosition,
+                    onDismiss = { isLyricsShareMode = false }
+                )
+            }
 
             if (text?.isNotEmpty() == true) {
                 if (isShowingSynchronizedLyrics) {
@@ -2330,6 +2362,15 @@ fun Lyrics(
                                             onClick = {
                                                 menuState.hide()
                                                 copyToClipboard = true
+                                            }
+                                        )
+
+                                        MenuEntry(
+                                            icon = R.drawable.share_social,
+                                            text = stringResource(R.string.lyrics_share_as_image),
+                                            onClick = {
+                                                menuState.hide()
+                                                isLyricsShareMode = true
                                             }
                                         )
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -878,6 +878,7 @@ fun Lyrics(
                     thumbnailUrl = mediaMetadata.artworkUri?.toString(),
                     mediaId = mediaId,
                     currentPosition = player.currentPosition,
+                    syncedLyricsText = if (isShowingSynchronizedLyrics) text else null,
                     onDismiss = { isLyricsShareMode = false }
                 )
             }

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -916,4 +916,8 @@
     <string name="word_pin">Pin</string>
     <string name="word_unpin">Unpin\n</string>
     <string name="success_playlist_deleted">Deleted %s</string>
+    <string name="lyrics_share_as_image">Share lyrics as image</string>
+    <string name="lyrics_share_select_lines">Select lyrics to share</string>
+    <string name="lyrics_share_create_card">Share</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -916,7 +916,7 @@
     <string name="word_pin">Pin</string>
     <string name="word_unpin">Unpin\n</string>
     <string name="success_playlist_deleted">Deleted %s</string>
-    <string name="lyrics_share_as_image">Share lyrics as image</string>
+    <string name="lyrics_share">Share lyrics</string>
     <string name="lyrics_share_select_lines">Select lyrics to share</string>
     <string name="lyrics_share_create_card">Share</string>
     <string name="lyrics_share_create_video">Share Video</string>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -922,5 +922,6 @@
     <string name="lyrics_share_create_video">Share Video</string>
     <string name="lyrics_share_mode_image">Image</string>
     <string name="lyrics_share_mode_video">Video</string>
+    <string name="lyrics_share_mode_animated">Animated</string>
     <string name="cancel">Cancel</string>
 </resources>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -919,5 +919,8 @@
     <string name="lyrics_share_as_image">Share lyrics as image</string>
     <string name="lyrics_share_select_lines">Select lyrics to share</string>
     <string name="lyrics_share_create_card">Share</string>
+    <string name="lyrics_share_create_video">Share Video</string>
+    <string name="lyrics_share_mode_image">Image</string>
+    <string name="lyrics_share_mode_video">Video</string>
     <string name="cancel">Cancel</string>
 </resources>

--- a/composeApp/src/androidMain/res/xml/file_paths.xml
+++ b/composeApp/src/androidMain/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="shared_lyrics"
+        path="shared_lyrics/" />
+    <external-path
+        name="external_files"
+        path="." />
+</paths>

--- a/composeApp/src/github/AndroidManifest.xml
+++ b/composeApp/src/github/AndroidManifest.xml
@@ -7,15 +7,5 @@
             android:name="android.permission.REQUEST_INSTALL_PACKAGES"
             tools:node="merge"/>
 
-    <application>
-        <provider
-                android:name="androidx.core.content.FileProvider"
-                android:authorities="${applicationId}.provider"
-                android:exported="false"
-                android:grantUriPermissions="true">
-            <meta-data
-                    android:name="android.support.FILE_PROVIDER_PATHS"
-                    android:resource="@xml/provider_paths" />
-        </provider>
-    </application>
+    <application />
 </manifest>


### PR DESCRIPTION
## Summary

Adds video sharing mode to the lyrics card feature. Users can now share selected lyrics as a short MP4 video with the actual audio from the song playing over the card.

Closes #1917

> **Note:** This PR depends on #1916 (lyrics image card). Should be merged after that PR.

## Changes

- **Audio extraction** (`AudioSegmentExtractor.kt`): Reads audio from Media3 cache, transcodes Opus→AAC via MediaCodec, trims to the selected lyrics' timestamp range
- **Video encoding** (`LyricsVideoEncoder.kt`): Encodes lyrics card bitmap as H.264 video frames via EGL/GLES20 surface rendering, muxes with audio using a two-pass strategy
- **UI toggle**: Image/Video mode selector shown when synced lyrics are available
- **Share fixes**: Fixed FileProvider permission grant using clipData, fixed recycled bitmap crash from Coil memory cache

## Architecture

```
User selects lyrics → LRC timestamps → audio start/end
                                      ↓
                          Cache (Opus) → Decode → AAC encode → trimmed.m4a
                                      ↓
                    Lyrics card bitmap → H.264 encode → video.mp4
                                      ↓
                          Mux video.mp4 + trimmed.m4a → final.mp4
                                      ↓
                              Share via Intent (video/mp4)
```

## Fallback behavior
If audio extraction or video encoding fails (song not cached, codec error), gracefully falls back to sharing as an image card.

## Testing
- Tested video generation with Opus audio from YouTube streams
- Verified fallback to image on uncached songs
- Build compiles cleanly